### PR TITLE
feat: crew sharing, service reminders, project planning, and Garage Mode

### DIFF
--- a/.claude/commands/build-next.md
+++ b/.claude/commands/build-next.md
@@ -1,4 +1,4 @@
-You are a Wrench (builder agent) on the Vehicle Work Log Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
+You are a Wrench (builder agent) on the Crew Chief Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
 
 Read `SERVICE_WRITER.md` for the full Wrench protocol (task selection algorithm, concurrency protocol, and rules). Read `CLAUDE.md`, `AGENTS.md`, and `AGENT.md` for code conventions and safety rules. Then follow this workflow:
 

--- a/.claude/commands/groom-issues.md
+++ b/.claude/commands/groom-issues.md
@@ -1,4 +1,4 @@
-You are the Vehicle Work Log Service Writer. Your job is to groom GitHub Issues — triage new ones, build out specs, ask clarifying questions, reject out-of-scope requests, and revisit existing priorities.
+You are the Crew Chief Service Writer. Your job is to groom GitHub Issues — triage new ones, build out specs, ask clarifying questions, reject out-of-scope requests, and revisit existing priorities.
 
 Read `SERVICE_WRITER.md` for your full personality, decision framework, gatekeeping rules, security review guidelines, and grooming protocol. Then follow this workflow:
 
@@ -31,7 +31,7 @@ gh issue view <number>
 Then apply the grooming protocol from SERVICE_WRITER.md:
 
 ### a) Scope check
-- Does this issue relate to Vehicle Work Log's purpose (tracking work/maintenance on vehicles, users, mechanics, parts, reporting)?
+- Does this issue relate to Crew Chief's purpose (tracking work/maintenance on vehicles, users, mechanics, parts, reporting)?
 - If **out of scope**: Leave a polite comment explaining why, add the `wontfix` label, and close the issue.
 
 ### b) Security check

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: "\U0001F4A1 Feature Request"
-description: Suggest a new feature or improvement for Vehicle Work Log
+description: Suggest a new feature or improvement for Crew Chief
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/workflows/build-next.yml
+++ b/.github/workflows/build-next.yml
@@ -37,7 +37,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "github-actions[bot]"
           prompt: |
-            You are a Wrench (builder agent) on the Vehicle Work Log Pit Lane crew. You've been asked to implement issue #${{ inputs.issue_number }}.
+            You are a Wrench (builder agent) on the Crew Chief Pit Lane crew. You've been asked to implement issue #${{ inputs.issue_number }}.
 
             Read `SERVICE_WRITER.md` for the full Wrench protocol. Read `CLAUDE.md`, `AGENTS.md`, and `AGENT.md` for code conventions and safety rules. Then follow this workflow:
 
@@ -136,7 +136,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "github-actions[bot]"
           prompt: |
-            You are a Wrench (builder agent) on the Vehicle Work Log Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
+            You are a Wrench (builder agent) on the Crew Chief Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
 
             Read `SERVICE_WRITER.md` for the full Wrench protocol. Read `CLAUDE.md`, `AGENTS.md`, and `AGENT.md` for code conventions and safety rules. Then follow this workflow:
 

--- a/.github/workflows/groom-issues.yml
+++ b/.github/workflows/groom-issues.yml
@@ -32,7 +32,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: "true"
           prompt: |
-            You are the Vehicle Work Log Service Writer. Groom issue #${{ github.event.issue.number }}.
+            You are the Crew Chief Service Writer. Groom issue #${{ github.event.issue.number }}.
 
             Start by reading these files (use a single bash command: `cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`), then read the issue with `gh issue view ${{ github.event.issue.number }} -R ${{ github.repository }}`.
 
@@ -47,7 +47,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the Vehicle Work Log Service Writer. Groom issue #${{ inputs.issue_number }}.
+            You are the Crew Chief Service Writer. Groom issue #${{ inputs.issue_number }}.
 
             Start by reading these files (use a single bash command: `cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`), then read the issue with `gh issue view ${{ inputs.issue_number }} -R ${{ github.repository }}`.
 
@@ -62,7 +62,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the Vehicle Work Log Service Writer. Groom all ungroomed issues.
+            You are the Crew Chief Service Writer. Groom all ungroomed issues.
 
             Start by reading these files (use a single bash command: `cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`).
 
@@ -95,7 +95,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the Vehicle Work Log Service Writer. A human has responded to clarification questions on issue #${{ github.event.issue.number }}.
+            You are the Crew Chief Service Writer. A human has responded to clarification questions on issue #${{ github.event.issue.number }}.
 
             Start by reading context files (`cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`) and the full issue with comments (`gh issue view ${{ github.event.issue.number }} -R ${{ github.repository }} --comments`).
 
@@ -128,7 +128,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the Vehicle Work Log Service Writer. A `/groom` command was issued on issue #${{ github.event.issue.number }}. This is a (re-)groom — start fresh.
+            You are the Crew Chief Service Writer. A `/groom` command was issued on issue #${{ github.event.issue.number }}. This is a (re-)groom — start fresh.
 
             First, strip stale status labels in one command:
             ```bash

--- a/.github/workflows/test-driver.yml
+++ b/.github/workflows/test-driver.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the **Test Driver** on the Vehicle Work Log Pit Crew. Read `TEST_DRIVER.md` for your full protocol. Also read `AGENTS.md` for project context.
+            You are the **Test Driver** on the Crew Chief Pit Crew. Read `TEST_DRIVER.md` for your full protocol. Also read `AGENTS.md` for project context.
 
             ## Your task
 

--- a/CHIEF_MECHANIC.md
+++ b/CHIEF_MECHANIC.md
@@ -7,7 +7,7 @@
 > gets rebuilt vs. replaced.
 
 Read `AGENT.md` for full project context. This file defines the Chief
-Mechanic's persona for evaluating and evolving the Vehicle Work Log system.
+Mechanic's persona for evaluating and evolving the Crew Chief system.
 
 ## Identity
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Vehicle Work Log
+# CLAUDE.md — Crew Chief
 
 Quick reference for Claude Code sessions in this repo. Read `README.md` for
 user-facing context and tool-choice rationale.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,26 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
   data** and let the client navigate — use `window.location.assign()`
   for auth (forces full reload to pick up session cookie) or
   `useNavigate()` for mutations.
+- **Access is membership-based, not owner-only.** `vehicle_members` grants
+  crew access (roles: `owner` | `member`); every vehicle-scoped model
+  function calls `requireVehicleAccess({ vehicleId, userId })` from
+  `~/models/member.server` (or joins on `vehicle_members`). Owner-only
+  ops (delete vehicle, manage crew) use `requireVehicleOwner`. The
+  vehicle's `userId` column remains the owner. Invites for unknown
+  emails live in `vehicle_invites` and are claimed in `signupFn`.
 - **Ownership checks in queries**: any model function that takes an `id`
-  must scope by `userId` too. See `getVehicle({ id, userId })`.
+  must scope by `userId` (membership) too. See `getVehicle({ id, userId })`.
+- **Semantic color tokens, not raw palette classes** in app UI: use
+  `bg-surface`/`bg-card`/`bg-sunken`, `text-ink`/`text-ink-muted`,
+  `border-line`, `bg-accent`, `text-danger`/`warn`/`ok` (defined via
+  `@theme inline` in `app/styles.css`). Garage Mode toggles a `.garage`
+  class on `<html>` (high-contrast dark + 18px base font) — raw slate/red
+  classes won't reskin. Shared class recipes live in `app/components/ui.ts`.
+- **Dev server env comes from `.dev.vars`**, not the host process env —
+  the Cloudflare vite plugin runs SSR in workerd, which can't see shell
+  exports. Node-side tooling (drizzle-kit, seed, vitest) still reads
+  `DATABASE_URL` from the environment / `.env`. Keep both files in sync
+  (both are gitignored).
 - **Path alias**: `~/*` → `./app/*`.
 - **Biome `useHookAtTopLevel` is disabled for `.server.ts`, `server-fns.ts`,
   and `app/routes/**`** because TanStack Start's `use*`-named helpers are
@@ -97,7 +115,11 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
 4. `app/auth/session.server.ts` — session cookie config + `requireAuth()`
 5. `app/auth/server-fns.ts` — login/signup/logout/currentUser server fns
 6. `app/storage.server.ts` — `Storage` interface + LocalFS + R2 drivers
-7. `app/models/*.server.ts` — the only place that imports from `~/db/client`
+7. `app/models/*.server.ts` — the only place that imports from `~/db/client`;
+   `member.server.ts` (crew/invites/access), `reminder.server.ts`
+   (date+mileage due, recurring roll-forward), `project.server.ts`
+   (builds + parts pipeline; status vocab in `project.shared.ts` because
+   client code can't import values from `.server.ts` modules)
 8. `app/routes/*` — file-based routes, including `/files/$` streaming
    route and `/account/export` JSON bundle endpoint
 9. `wrangler.jsonc` — Cloudflare Workers config (Hyperdrive, R2, secrets)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Self-host image: app + Postgres 16 + s6-overlay, one mounted /app/data volume.
 # Run with:
-#   docker run -d -p 3000:3000 -v vwl-data:/app/data \
-#     -e SESSION_SECRET=... ghcr.io/scottprue/vehicle-work-log:latest
+#   docker run -d -p 3000:3000 -v crew-chief-data:/app/data \
+#     -e SESSION_SECRET=... ghcr.io/scottprue/crew-chief:latest
 
 ARG NODE_VERSION=24
 ARG S6_OVERLAY_VERSION=3.2.0.2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vehicle Work Log
+# Crew Chief
 
 A personal maintenance log for every car you own. Track services, parts,
 odometer, cost, and notes per vehicle. Export your whole history as JSON
@@ -127,9 +127,9 @@ single container. One command, one mounted volume:
 ```sh
 docker run -d \
   -p 3000:3000 \
-  -v vwl-data:/app/data \
+  -v crew-chief-data:/app/data \
   -e SESSION_SECRET="$(openssl rand -base64 48)" \
-  ghcr.io/scottprue/vehicle-work-log:latest
+  ghcr.io/scottprue/crew-chief:latest
 ```
 
 Everything persistent (Postgres cluster + uploaded files) lives under

--- a/README.md
+++ b/README.md
@@ -5,6 +5,24 @@ odometer, cost, and notes per vehicle. Export your whole history as JSON
 whenever you want — and run your own instance on a single `docker run` if you
 don't want to rely on any hosted provider.
 
+What it does today:
+
+- **Work logs** — quick-capture form with tap-to-fill presets (oil change,
+  brake pads, …), odometer/cost, and full-text search.
+- **Crew sharing** — invite someone by email to any vehicle; members see
+  and log everything on shared vehicles (invites for new emails are
+  claimed automatically at signup).
+- **Service reminders** — due by date *and/or* mileage, with recurring
+  intervals (every 5,000 mi / 6 mo). Urgency is computed from the latest
+  logged odometer, and logging the work completes the reminder and rolls
+  it forward.
+- **Projects** — plan bigger builds (e.g. rally prep): parts with prices
+  and links through a proposed → ordered → received → installed pipeline,
+  estimated vs committed budget, and a countdown to a target date.
+- **Garage Mode** — one tap flips the whole app to a high-contrast dark
+  theme with bigger type and fat touch targets, for reading at arm's
+  length under bad shop lighting. Mobile-first throughout.
+
 This repo originally ran on Remix + Fly + Postgres + MinIO. It was rebuilt
 from the ground up in 2026 on a TanStack Start stack targeting Cloudflare
 Workers, with a first-class self-host path that ships as a single Docker
@@ -67,9 +85,12 @@ npm install
 # 2. Start local Postgres (pgvector image, on port 5440)
 npm run docker:dev
 
-# 3. Seed env
+# 3. Seed env — .env feeds Node tooling (drizzle-kit, seed, vitest);
+#    .dev.vars feeds the dev server's SSR, which runs inside workerd via
+#    the Cloudflare vite plugin and can't see your shell env.
 cp .env.example .env
-# (SESSION_SECRET in .env must be ≥ 32 characters)
+cp .env.example .dev.vars
+# (SESSION_SECRET must be ≥ 32 characters; keep both files in sync)
 
 # 4. Run migrations + seed
 npm run db:migrate
@@ -318,6 +339,14 @@ Near-term:
   produces a working `.output/server/index.mjs`
 - Reinstate the `_authed` `beforeLoad` guard once `useSession` works from
   loaders
+
+Near-term, garage edition:
+
+- Photos on work logs (storage layer already handles uploads)
+- Email/push notifications when a reminder goes overdue
+- Fuel tracking (fill-ups double as cheap odometer updates for reminders)
+- Printable maintenance history per vehicle (rally tech-inspection sheet)
+- Event checklists on projects (recurring rally-prep template)
 
 Beyond that:
 

--- a/SERVICE_WRITER.md
+++ b/SERVICE_WRITER.md
@@ -7,7 +7,7 @@
 
 ## Identity
 
-You are the **Service Writer** for Vehicle Work Log — the PM agent on the
+You are the **Service Writer** for Crew Chief — the PM agent on the
 **Pit Lane** crew. You operate with memory across sessions, maintaining a
 living roadmap and making prioritization decisions grounded in user
 feedback, usage data, and the project's goal: a reliable, pleasant web app
@@ -75,7 +75,7 @@ When prioritizing, weight these factors:
 ### Gatekeeping & Scope Enforcement
 
 You are the **first line of defense** for the backlog. Not every request
-belongs in Vehicle Work Log's roadmap. Your job is to say **no** when
+belongs in Crew Chief's roadmap. Your job is to say **no** when
 appropriate.
 
 **Accept** issues that:
@@ -130,7 +130,7 @@ follow this process for **each issue**:
 #### For new issues (no priority label yet):
 
 1. **Read** the full issue body and any existing comments
-2. **Validate scope** — Does this belong in Vehicle Work Log? If not, reject
+2. **Validate scope** — Does this belong in Crew Chief? If not, reject
    per gatekeeping rules above
 3. **Security check** — Does anything look suspicious or unsafe? If so, flag
    per security rules above
@@ -191,7 +191,7 @@ follow this process for **each issue**:
 
 ## Context
 
-### What Vehicle Work Log Does Today
+### What Crew Chief Does Today
 
 - **Users** — register (`/join`), login (`/login`), logout (`/logout`). Cookie
   sessions via `createCookieSessionStorage`.

--- a/app/auth/server-fns.ts
+++ b/app/auth/server-fns.ts
@@ -1,5 +1,6 @@
 import { createServerFn } from "@tanstack/react-start";
 
+import { claimPendingInvites } from "~/models/member.server";
 import {
   createUser,
   getUserByEmail,
@@ -45,6 +46,7 @@ export const signupFn = createServerFn({ method: "POST" })
       return { error: "A user with this email already exists" };
     }
     const user = await createUser(data.email, data.password);
+    await claimPendingInvites({ userId: user.id, email: user.email });
     const session = await useAppSession();
     await session.update({ userId: user.id });
     return { redirectTo: safeRedirect(data.redirectTo) };

--- a/app/components/reminder-display.ts
+++ b/app/components/reminder-display.ts
@@ -1,0 +1,46 @@
+import type { ReminderStatus } from "~/models/reminder.server";
+
+type StatusInfo = {
+  status: ReminderStatus;
+  daysLeft: number | null;
+  milesLeft: number | null;
+};
+
+export function statusBadgeClass(status: ReminderStatus): string {
+  const base =
+    "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-bold";
+  switch (status) {
+    case "overdue":
+      return `${base} bg-danger/15 text-danger`;
+    case "due_soon":
+      return `${base} bg-warn/15 text-warn`;
+    case "done":
+      return `${base} bg-sunken text-ink-muted`;
+    default:
+      return `${base} bg-ok/15 text-ok`;
+  }
+}
+
+/** "overdue by 3 days" / "in 12 days · 300 mi left" / "done". */
+export function statusLabel({
+  status,
+  daysLeft,
+  milesLeft,
+}: StatusInfo): string {
+  if (status === "done") return "done";
+  const parts: string[] = [];
+  if (daysLeft != null) {
+    if (daysLeft <= 0) {
+      parts.push(daysLeft === 0 ? "due today" : `${-daysLeft}d overdue`);
+    } else {
+      parts.push(`in ${daysLeft}d`);
+    }
+  }
+  if (milesLeft != null) {
+    const miles = Math.round(Math.abs(milesLeft)).toLocaleString();
+    parts.push(milesLeft <= 0 ? `${miles} mi past` : `${miles} mi left`);
+  }
+  if (parts.length === 0)
+    return status === "overdue" ? "overdue" : "no due set";
+  return parts.join(" · ");
+}

--- a/app/components/ui.ts
+++ b/app/components/ui.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared Tailwind class recipes so every screen uses the same garage-friendly
+ * sizing: ≥44px touch targets, semantic color tokens (see styles.css).
+ */
+
+export const card = "rounded-2xl border border-line bg-card shadow-sm";
+
+const btnBase =
+  "inline-flex min-h-11 items-center justify-center gap-2 rounded-xl px-4 font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent disabled:opacity-50 active:scale-[.98]";
+
+export const btnPrimary = `${btnBase} bg-accent text-accent-ink hover:bg-accent-strong`;
+
+export const btnSecondary = `${btnBase} border border-line bg-card text-ink hover:bg-sunken`;
+
+export const btnDanger = `${btnBase} border border-danger/40 bg-card text-danger hover:bg-danger/10`;
+
+export const input =
+  "mt-1 block w-full min-h-11 rounded-xl border border-line bg-card px-3 text-ink placeholder:text-ink-muted focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30";
+
+export const textarea =
+  "mt-1 block w-full rounded-xl border border-line bg-card p-3 text-ink placeholder:text-ink-muted focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30";
+
+export const label = "block text-sm font-medium text-ink-muted";
+
+export const errorBox =
+  "rounded-xl border border-danger/40 bg-danger/10 p-3 text-sm text-danger";
+
+/** Selectable pill (service-type presets, status filters). */
+export function chip(selected: boolean) {
+  return `inline-flex min-h-11 items-center rounded-full border px-4 text-sm font-semibold transition-colors ${
+    selected
+      ? "border-accent bg-accent text-accent-ink"
+      : "border-line bg-card text-ink hover:bg-sunken"
+  }`;
+}

--- a/app/db/migrations/0002_supreme_dreaming_celestial.sql
+++ b/app/db/migrations/0002_supreme_dreaming_celestial.sql
@@ -1,0 +1,77 @@
+CREATE TABLE "project_items" (
+	"id" text PRIMARY KEY NOT NULL,
+	"project_id" text NOT NULL,
+	"name" text NOT NULL,
+	"url" text,
+	"price" double precision,
+	"quantity" integer DEFAULT 1 NOT NULL,
+	"status" text DEFAULT 'proposed' NOT NULL,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "projects" (
+	"id" text PRIMARY KEY NOT NULL,
+	"vehicle_id" text NOT NULL,
+	"title" text NOT NULL,
+	"description" text,
+	"status" text DEFAULT 'idea' NOT NULL,
+	"target_date" timestamp with time zone,
+	"created_by_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "reminders" (
+	"id" text PRIMARY KEY NOT NULL,
+	"vehicle_id" text NOT NULL,
+	"title" text NOT NULL,
+	"notes" text,
+	"due_date" timestamp with time zone,
+	"due_miles" double precision,
+	"interval_months" integer,
+	"interval_miles" double precision,
+	"completed_at" timestamp with time zone,
+	"created_by_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "vehicle_invites" (
+	"id" text PRIMARY KEY NOT NULL,
+	"vehicle_id" text NOT NULL,
+	"email" text NOT NULL,
+	"invited_by_id" text,
+	"accepted_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "vehicle_members" (
+	"vehicle_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"role" text DEFAULT 'member' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "vehicle_members_vehicle_id_user_id_pk" PRIMARY KEY("vehicle_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "project_items" ADD CONSTRAINT "project_items_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_vehicle_id_vehicles_id_fk" FOREIGN KEY ("vehicle_id") REFERENCES "public"."vehicles"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_created_by_id_users_id_fk" FOREIGN KEY ("created_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "reminders" ADD CONSTRAINT "reminders_vehicle_id_vehicles_id_fk" FOREIGN KEY ("vehicle_id") REFERENCES "public"."vehicles"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "reminders" ADD CONSTRAINT "reminders_created_by_id_users_id_fk" FOREIGN KEY ("created_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vehicle_invites" ADD CONSTRAINT "vehicle_invites_vehicle_id_vehicles_id_fk" FOREIGN KEY ("vehicle_id") REFERENCES "public"."vehicles"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "vehicle_invites" ADD CONSTRAINT "vehicle_invites_invited_by_id_users_id_fk" FOREIGN KEY ("invited_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vehicle_members" ADD CONSTRAINT "vehicle_members_vehicle_id_vehicles_id_fk" FOREIGN KEY ("vehicle_id") REFERENCES "public"."vehicles"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "vehicle_members" ADD CONSTRAINT "vehicle_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+CREATE INDEX "project_items_project_idx" ON "project_items" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "projects_vehicle_idx" ON "projects" USING btree ("vehicle_id");--> statement-breakpoint
+CREATE INDEX "reminders_vehicle_idx" ON "reminders" USING btree ("vehicle_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "vehicle_invites_vehicle_email_idx" ON "vehicle_invites" USING btree ("vehicle_id","email");--> statement-breakpoint
+CREATE INDEX "vehicle_invites_email_idx" ON "vehicle_invites" USING btree ("email");--> statement-breakpoint
+CREATE INDEX "vehicle_members_user_idx" ON "vehicle_members" USING btree ("user_id");--> statement-breakpoint
+INSERT INTO "vehicle_members" ("vehicle_id", "user_id", "role")
+SELECT "id", "user_id", 'owner' FROM "vehicles"
+ON CONFLICT DO NOTHING;

--- a/app/db/migrations/meta/0002_snapshot.json
+++ b/app/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1258 @@
+{
+  "id": "089c7914-a113-4b4d-98a8-54f25b5fbcd1",
+  "prevId": "e05bb2b1-31bd-456c-9ce7-ef2855633036",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serviced_at": {
+          "name": "serviced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "self_service": {
+          "name": "self_service",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mechanic_id": {
+          "name": "mechanic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(\"logs\".\"title\", '') || ' ' || coalesce(\"logs\".\"notes\", ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_search_idx": {
+          "name": "logs_search_idx",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "logs_vehicle_idx": {
+          "name": "logs_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_user_idx": {
+          "name": "logs_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "logs_user_id_users_id_fk": {
+          "name": "logs_user_id_users_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "logs_vehicle_id_vehicles_id_fk": {
+          "name": "logs_vehicle_id_vehicles_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "logs_mechanic_id_mechanics_id_fk": {
+          "name": "logs_mechanic_id_mechanics_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "mechanics",
+          "columnsFrom": [
+            "mechanic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_to_parts": {
+      "name": "logs_to_parts",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logs_to_parts_log_id_logs_id_fk": {
+          "name": "logs_to_parts_log_id_logs_id_fk",
+          "tableFrom": "logs_to_parts",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "logs_to_parts_part_id_parts_id_fk": {
+          "name": "logs_to_parts_part_id_parts_id_fk",
+          "tableFrom": "logs_to_parts",
+          "tableTo": "parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "logs_to_parts_log_id_part_id_pk": {
+          "name": "logs_to_parts_log_id_part_id_pk",
+          "columns": [
+            "log_id",
+            "part_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_to_tags": {
+      "name": "logs_to_tags",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logs_to_tags_log_id_logs_id_fk": {
+          "name": "logs_to_tags_log_id_logs_id_fk",
+          "tableFrom": "logs_to_tags",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "logs_to_tags_tag_id_tags_id_fk": {
+          "name": "logs_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "logs_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "logs_to_tags_log_id_tag_id_pk": {
+          "name": "logs_to_tags_log_id_tag_id_pk",
+          "columns": [
+            "log_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mechanics": {
+      "name": "mechanics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mechanics_email_idx": {
+          "name": "mechanics_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parts": {
+      "name": "parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passwords": {
+      "name": "passwords",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passwords_user_id_users_id_fk": {
+          "name": "passwords_user_id_users_id_fk",
+          "tableFrom": "passwords",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passwords_user_id_unique": {
+          "name": "passwords_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_items": {
+      "name": "project_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_items_project_idx": {
+          "name": "project_items_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_items_project_id_projects_id_fk": {
+          "name": "project_items_project_id_projects_id_fk",
+          "tableFrom": "project_items",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idea'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_vehicle_idx": {
+          "name": "projects_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_vehicle_id_vehicles_id_fk": {
+          "name": "projects_vehicle_id_vehicles_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "projects_created_by_id_users_id_fk": {
+          "name": "projects_created_by_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reminders": {
+      "name": "reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_miles": {
+          "name": "due_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_months": {
+          "name": "interval_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_miles": {
+          "name": "interval_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reminders_vehicle_idx": {
+          "name": "reminders_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reminders_vehicle_id_vehicles_id_fk": {
+          "name": "reminders_vehicle_id_vehicles_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "reminders_created_by_id_users_id_fk": {
+          "name": "reminders_created_by_id_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_invites": {
+      "name": "vehicle_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_invites_vehicle_email_idx": {
+          "name": "vehicle_invites_vehicle_email_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vehicle_invites_email_idx": {
+          "name": "vehicle_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_invites_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_invites_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_invites",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_invites_invited_by_id_users_id_fk": {
+          "name": "vehicle_invites_invited_by_id_users_id_fk",
+          "tableFrom": "vehicle_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_members": {
+      "name": "vehicle_members",
+      "schema": "",
+      "columns": {
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_members_user_idx": {
+          "name": "vehicle_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_members_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_members_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_members",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_members_user_id_users_id_fk": {
+          "name": "vehicle_members_user_id_users_id_fk",
+          "tableFrom": "vehicle_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vehicle_members_vehicle_id_user_id_pk": {
+          "name": "vehicle_members_vehicle_id_user_id_pk",
+          "columns": [
+            "vehicle_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trim": {
+          "name": "trim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vehicles_user_id_users_id_fk": {
+          "name": "vehicles_user_id_users_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/db/migrations/meta/_journal.json
+++ b/app/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777051844962,
       "tag": "0001_clever_marauders",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781154272988,
+      "tag": "0002_supreme_dreaming_celestial",
+      "breakpoints": true
     }
   ]
 }

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -117,6 +117,131 @@ export const logs = pgTable(
   ],
 );
 
+// Crew: users who share access to a vehicle. The vehicle's `userId` column
+// remains the owner; members get full read/write on logs, reminders, and
+// projects but cannot delete the vehicle or manage the crew.
+export const vehicleMembers = pgTable(
+  "vehicle_members",
+  {
+    vehicleId: text("vehicle_id")
+      .notNull()
+      .references(() => vehicles.id, {
+        onDelete: "cascade",
+        onUpdate: "cascade",
+      }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade", onUpdate: "cascade" }),
+    role: text().notNull().default("member"), // "owner" | "member"
+    ...timestamps,
+  },
+  (t) => [
+    primaryKey({ columns: [t.vehicleId, t.userId] }),
+    index("vehicle_members_user_idx").on(t.userId),
+  ],
+);
+
+// Pending crew invites for emails that don't have an account yet. Claimed
+// (converted to a membership) on signup; emails are stored lowercased.
+export const vehicleInvites = pgTable(
+  "vehicle_invites",
+  {
+    id: cuid2().primaryKey(),
+    vehicleId: text("vehicle_id")
+      .notNull()
+      .references(() => vehicles.id, {
+        onDelete: "cascade",
+        onUpdate: "cascade",
+      }),
+    email: text().notNull(),
+    invitedById: text("invited_by_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    acceptedAt: timestamp("accepted_at", { withTimezone: true, mode: "date" }),
+    ...timestamps,
+  },
+  (t) => [
+    uniqueIndex("vehicle_invites_vehicle_email_idx").on(t.vehicleId, t.email),
+    index("vehicle_invites_email_idx").on(t.email),
+  ],
+);
+
+// Service reminders. Due by date and/or mileage (either may be null). When
+// intervalMonths/intervalMiles are set the reminder recurs: completing it
+// advances the due date/miles instead of setting completedAt.
+export const reminders = pgTable(
+  "reminders",
+  {
+    id: cuid2().primaryKey(),
+    vehicleId: text("vehicle_id")
+      .notNull()
+      .references(() => vehicles.id, {
+        onDelete: "cascade",
+        onUpdate: "cascade",
+      }),
+    title: text().notNull(),
+    notes: text(),
+    dueDate: timestamp("due_date", { withTimezone: true, mode: "date" }),
+    dueMiles: doublePrecision("due_miles"),
+    intervalMonths: integer("interval_months"),
+    intervalMiles: doublePrecision("interval_miles"),
+    completedAt: timestamp("completed_at", {
+      withTimezone: true,
+      mode: "date",
+    }),
+    createdById: text("created_by_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    ...timestamps,
+  },
+  (t) => [index("reminders_vehicle_idx").on(t.vehicleId)],
+);
+
+// Planned work — e.g. a rally-prep build. Items track parts through a
+// proposed → ordered → received → installed pipeline with prices.
+export const projects = pgTable(
+  "projects",
+  {
+    id: cuid2().primaryKey(),
+    vehicleId: text("vehicle_id")
+      .notNull()
+      .references(() => vehicles.id, {
+        onDelete: "cascade",
+        onUpdate: "cascade",
+      }),
+    title: text().notNull(),
+    description: text(),
+    status: text().notNull().default("idea"), // "idea" | "planned" | "in_progress" | "done"
+    targetDate: timestamp("target_date", { withTimezone: true, mode: "date" }),
+    createdById: text("created_by_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    ...timestamps,
+  },
+  (t) => [index("projects_vehicle_idx").on(t.vehicleId)],
+);
+
+export const projectItems = pgTable(
+  "project_items",
+  {
+    id: cuid2().primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, {
+        onDelete: "cascade",
+        onUpdate: "cascade",
+      }),
+    name: text().notNull(),
+    url: text(),
+    price: doublePrecision(),
+    quantity: integer().notNull().default(1),
+    status: text().notNull().default("proposed"), // "proposed" | "ordered" | "received" | "installed"
+    notes: text(),
+    ...timestamps,
+  },
+  (t) => [index("project_items_project_idx").on(t.projectId)],
+);
+
 export const tags = pgTable(
   "tags",
   {
@@ -170,3 +295,11 @@ export type NewLog = typeof logs.$inferInsert;
 export type Mechanic = typeof mechanics.$inferSelect;
 export type Tag = typeof tags.$inferSelect;
 export type Part = typeof parts.$inferSelect;
+export type VehicleMember = typeof vehicleMembers.$inferSelect;
+export type VehicleInvite = typeof vehicleInvites.$inferSelect;
+export type Reminder = typeof reminders.$inferSelect;
+export type NewReminder = typeof reminders.$inferInsert;
+export type Project = typeof projects.$inferSelect;
+export type NewProject = typeof projects.$inferInsert;
+export type ProjectItem = typeof projectItems.$inferSelect;
+export type NewProjectItem = typeof projectItems.$inferInsert;

--- a/app/db/seed.ts
+++ b/app/db/seed.ts
@@ -2,7 +2,18 @@ import bcrypt from "bcryptjs";
 import { eq } from "drizzle-orm";
 
 import { createDb } from "./client";
-import { passwords, users, vehicles } from "./schema";
+import {
+  logs,
+  passwords,
+  projectItems,
+  projects,
+  reminders,
+  users,
+  vehicleMembers,
+  vehicles,
+} from "./schema";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 async function main() {
   const url = process.env.DATABASE_URL;
@@ -27,14 +38,87 @@ async function main() {
   if (!user) throw new Error("Failed to create seed user");
   await db.insert(passwords).values({ userId: user.id, hash });
 
-  await db.insert(vehicles).values({
+  const [vehicle] = await db
+    .insert(vehicles)
+    .values({
+      userId: user.id,
+      make: "Subaru",
+      model: "WRX",
+      year: 2007,
+      name: "Rally Car",
+    })
+    .returning();
+  if (!vehicle) throw new Error("Failed to create seed vehicle");
+  await db.insert(vehicleMembers).values({
+    vehicleId: vehicle.id,
     userId: user.id,
-    make: "Subaru",
-    model: "WRX",
-    year: 2007,
+    role: "owner",
   });
 
-  console.log(`[seed] created ${email} and one vehicle`);
+  await db.insert(logs).values({
+    userId: user.id,
+    vehicleId: vehicle.id,
+    title: "Oil change",
+    notes: "5W-30 synthetic, OEM filter",
+    type: "Minor",
+    odometer: 98200,
+    cost: 64.5,
+    selfService: true,
+    servicedAt: new Date(Date.now() - 20 * DAY_MS),
+  });
+
+  await db.insert(reminders).values([
+    {
+      vehicleId: vehicle.id,
+      title: "Oil change",
+      notes: "5W-30 synthetic",
+      dueMiles: 103200,
+      intervalMiles: 5000,
+      intervalMonths: 6,
+      dueDate: new Date(Date.now() + 160 * DAY_MS),
+      createdById: user.id,
+    },
+    {
+      vehicleId: vehicle.id,
+      title: "Front brake pads",
+      dueMiles: 98700,
+      createdById: user.id,
+    },
+  ]);
+
+  const [project] = await db
+    .insert(projects)
+    .values({
+      vehicleId: vehicle.id,
+      title: "Rally prep",
+      description: "Service + spares before the next event",
+      status: "planned",
+      targetDate: new Date(Date.now() + 45 * DAY_MS),
+      createdById: user.id,
+    })
+    .returning();
+  if (project) {
+    await db.insert(projectItems).values([
+      {
+        projectId: project.id,
+        name: "Hawk DTC-30 front pads",
+        price: 189,
+        quantity: 1,
+        status: "proposed",
+      },
+      {
+        projectId: project.id,
+        name: "Spare gravel tires",
+        price: 140,
+        quantity: 2,
+        status: "ordered",
+      },
+    ]);
+  }
+
+  console.log(
+    `[seed] created ${email} with vehicle, log, reminders, and a project`,
+  );
   await close();
 }
 

--- a/app/models/log.server.test.ts
+++ b/app/models/log.server.test.ts
@@ -1,8 +1,10 @@
+import { eq } from "drizzle-orm";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { createDb } from "~/db/client";
-import { users, vehicles } from "~/db/schema";
+import { users } from "~/db/schema";
 import { createLog, searchLogs } from "~/models/log.server";
+import { createVehicle } from "~/models/vehicle.server";
 
 // Integration test — requires DATABASE_URL pointing at a running local Postgres
 // with migrations applied. Run via: node --env-file=.env npm test
@@ -23,16 +25,19 @@ beforeAll(async () => {
   if (!user) throw new Error("user insert failed");
   userId = user.id;
 
-  const [vehicle] = await db
-    .insert(vehicles)
-    .values({ userId, make: "Test", model: "Vehicle", year: 2020 })
-    .returning();
-  if (!vehicle) throw new Error("vehicle insert failed");
+  // createVehicle (not a raw insert) so the owner membership row exists —
+  // log access is granted via vehicle_members.
+  const vehicle = await createVehicle({
+    userId,
+    make: "Test",
+    model: "Vehicle",
+    year: 2020,
+  });
   vehicleId = vehicle.id;
 });
 
 afterAll(async () => {
-  // Cascade deletes logs + vehicles
+  // Cascade deletes memberships + logs + vehicles
   await db.delete(users).where(eq(users.id, userId));
   await close();
 });
@@ -74,16 +79,12 @@ describe("searchLogs", () => {
       .returning();
     if (!otherUser) throw new Error("other user insert failed");
     try {
-      const [otherVehicle] = await db
-        .insert(vehicles)
-        .values({
-          userId: otherUser.id,
-          make: "Other",
-          model: "Vehicle",
-          year: 2020,
-        })
-        .returning();
-      if (!otherVehicle) throw new Error("other vehicle insert failed");
+      const otherVehicle = await createVehicle({
+        userId: otherUser.id,
+        make: "Other",
+        model: "Vehicle",
+        year: 2020,
+      });
       await createLog({
         userId: otherUser.id,
         vehicleId: otherVehicle.id,
@@ -95,6 +96,19 @@ describe("searchLogs", () => {
       await db.delete(users).where(eq(users.id, otherUser.id));
     }
   });
-});
 
-import { eq } from "drizzle-orm";
+  it("rejects log access on vehicles the user is not a member of", async () => {
+    const [stranger] = await db
+      .insert(users)
+      .values({ email: `stranger-${Date.now()}@example.com` })
+      .returning();
+    if (!stranger) throw new Error("stranger insert failed");
+    try {
+      await expect(
+        createLog({ userId: stranger.id, vehicleId, title: "Drive-by log" }),
+      ).rejects.toThrow("Vehicle not found");
+    } finally {
+      await db.delete(users).where(eq(users.id, stranger.id));
+    }
+  });
+});

--- a/app/models/log.server.ts
+++ b/app/models/log.server.ts
@@ -2,42 +2,81 @@ import { and, desc, eq, sql } from "drizzle-orm";
 
 import { getDb } from "~/db/client";
 import type { Log, NewLog } from "~/db/schema";
-import { logs } from "~/db/schema";
+import { logs, users, vehicleMembers } from "~/db/schema";
+import { requireVehicleAccess } from "~/models/member.server";
 
 export type { Log };
 
+export type LogListItem = Log & {
+  authorName: string | null;
+};
+
+/**
+ * `userId` here is the requesting user — access is granted via crew
+ * membership on the vehicle, not log authorship.
+ */
 export async function getLog({
   id,
   userId,
   vehicleId,
-}: Pick<Log, "id" | "userId" | "vehicleId">) {
+}: Pick<Log, "id" | "userId" | "vehicleId">): Promise<LogListItem | null> {
+  await requireVehicleAccess({ vehicleId, userId });
   const db = await getDb();
-  const [log] = await db
-    .select()
+  const [row] = await db
+    .select({
+      log: logs,
+      authorName: sql<
+        string | null
+      >`coalesce(${users.displayName}, ${users.email})`,
+    })
     .from(logs)
-    .where(
-      and(
-        eq(logs.id, id),
-        eq(logs.userId, userId),
-        eq(logs.vehicleId, vehicleId),
-      ),
-    );
-  return log ?? null;
+    .leftJoin(users, eq(users.id, logs.userId))
+    .where(and(eq(logs.id, id), eq(logs.vehicleId, vehicleId)));
+  if (!row) return null;
+  return { ...row.log, authorName: row.authorName };
 }
 
 export async function getLogListItems({
   userId,
   vehicleId,
-}: Pick<Log, "userId" | "vehicleId">) {
+  limit,
+}: Pick<Log, "userId" | "vehicleId"> & {
+  limit?: number;
+}): Promise<LogListItem[]> {
+  await requireVehicleAccess({ vehicleId, userId });
   const db = await getDb();
-  return db
-    .select()
+  const query = db
+    .select({
+      log: logs,
+      authorName: sql<
+        string | null
+      >`coalesce(${users.displayName}, ${users.email})`,
+    })
     .from(logs)
-    .where(and(eq(logs.userId, userId), eq(logs.vehicleId, vehicleId)))
-    .orderBy(desc(logs.updatedAt));
+    .leftJoin(users, eq(users.id, logs.userId))
+    .where(eq(logs.vehicleId, vehicleId))
+    .orderBy(desc(logs.servicedAt), desc(logs.createdAt));
+  const rows = await (limit != null ? query.limit(limit) : query);
+  return rows.map((r) => ({ ...r.log, authorName: r.authorName }));
+}
+
+/** Highest odometer ever logged for the vehicle (best guess at current). */
+export async function getLatestOdometer({
+  vehicleId,
+}: Pick<Log, "vehicleId">): Promise<number | null> {
+  const db = await getDb();
+  const [row] = await db
+    .select({ latest: sql<number | null>`max(${logs.odometer})` })
+    .from(logs)
+    .where(eq(logs.vehicleId, vehicleId));
+  return row?.latest ?? null;
 }
 
 export async function createLog(input: NewLog) {
+  await requireVehicleAccess({
+    vehicleId: input.vehicleId,
+    userId: input.userId,
+  });
   const db = await getDb();
   const [log] = await db.insert(logs).values(input).returning();
   if (!log) throw new Error("Failed to create log");
@@ -49,21 +88,16 @@ export async function deleteLog({
   userId,
   vehicleId,
 }: Pick<Log, "id" | "userId" | "vehicleId">) {
+  await requireVehicleAccess({ vehicleId, userId });
   const db = await getDb();
   return db
     .delete(logs)
-    .where(
-      and(
-        eq(logs.id, id),
-        eq(logs.userId, userId),
-        eq(logs.vehicleId, vehicleId),
-      ),
-    );
+    .where(and(eq(logs.id, id), eq(logs.vehicleId, vehicleId)));
 }
 
 /**
- * Full-text search over a user's logs using the generated `search_tsv` column
- * + GIN index. Returns logs ordered by updatedAt desc.
+ * Full-text search over logs on every vehicle the user can access, using
+ * the generated `search_tsv` column + GIN index.
  */
 export async function searchLogs({
   userId,
@@ -76,14 +110,17 @@ export async function searchLogs({
   const trimmed = query.trim();
   if (!trimmed) return [];
 
-  return db
-    .select()
+  const rows = await db
+    .select({ log: logs })
     .from(logs)
-    .where(
+    .innerJoin(
+      vehicleMembers,
       and(
-        eq(logs.userId, userId),
-        sql`${logs.searchTsv} @@ plainto_tsquery('english', ${trimmed})`,
+        eq(vehicleMembers.vehicleId, logs.vehicleId),
+        eq(vehicleMembers.userId, userId),
       ),
     )
+    .where(sql`${logs.searchTsv} @@ plainto_tsquery('english', ${trimmed})`)
     .orderBy(desc(logs.updatedAt));
+  return rows.map((r) => r.log);
 }

--- a/app/models/member.server.test.ts
+++ b/app/models/member.server.test.ts
@@ -1,0 +1,135 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createDb } from "~/db/client";
+import { users } from "~/db/schema";
+import { createLog, getLogListItems } from "~/models/log.server";
+import {
+  claimPendingInvites,
+  inviteToCrew,
+  listCrew,
+  removeCrewMember,
+} from "~/models/member.server";
+import { createVehicle, getVehicle } from "~/models/vehicle.server";
+
+const url = process.env.DATABASE_URL;
+if (!url) throw new Error("DATABASE_URL is required for member.server.test.ts");
+
+const { db, close } = createDb(url);
+
+const stamp = Date.now();
+let ownerId: string;
+let wifeId: string;
+let vehicleId: string;
+
+beforeAll(async () => {
+  const [owner] = await db
+    .insert(users)
+    .values({ email: `crew-owner-${stamp}@example.com` })
+    .returning();
+  const [wife] = await db
+    .insert(users)
+    .values({ email: `crew-wife-${stamp}@example.com` })
+    .returning();
+  if (!owner || !wife) throw new Error("user insert failed");
+  ownerId = owner.id;
+  wifeId = wife.id;
+
+  const vehicle = await createVehicle({
+    userId: ownerId,
+    make: "Subaru",
+    model: "WRX",
+    year: 2007,
+  });
+  vehicleId = vehicle.id;
+});
+
+afterAll(async () => {
+  await db.delete(users).where(eq(users.id, ownerId));
+  await db.delete(users).where(eq(users.id, wifeId));
+  await close();
+});
+
+describe("crew sharing", () => {
+  it("creating a vehicle makes the creator the owner", async () => {
+    const vehicle = await getVehicle({ id: vehicleId, userId: ownerId });
+    expect(vehicle?.role).toBe("owner");
+  });
+
+  it("inviting an existing user adds them immediately with member role", async () => {
+    const result = await inviteToCrew({
+      vehicleId,
+      userId: ownerId,
+      email: `crew-wife-${stamp}@example.com`,
+    });
+    expect(result.status).toBe("added");
+
+    const vehicle = await getVehicle({ id: vehicleId, userId: wifeId });
+    expect(vehicle?.role).toBe("member");
+  });
+
+  it("members can read and write logs on the shared vehicle", async () => {
+    await createLog({
+      userId: wifeId,
+      vehicleId,
+      title: "Swapped rally tires",
+    });
+    const logs = await getLogListItems({ userId: ownerId, vehicleId });
+    expect(logs.some((l) => l.title === "Swapped rally tires")).toBe(true);
+  });
+
+  it("members cannot invite others (owner only)", async () => {
+    await expect(
+      inviteToCrew({
+        vehicleId,
+        userId: wifeId,
+        email: "someone-else@example.com",
+      }),
+    ).rejects.toThrow("Only the owner");
+  });
+
+  it("inviting an unknown email stores a pending invite claimed at signup", async () => {
+    const email = `crew-future-${stamp}@example.com`;
+    const result = await inviteToCrew({ vehicleId, userId: ownerId, email });
+    expect(result.status).toBe("invited");
+
+    const crew = await listCrew({ vehicleId, userId: ownerId });
+    expect(crew.pendingInvites.some((i) => i.email === email)).toBe(true);
+
+    // ...the future user signs up:
+    const [futureUser] = await db.insert(users).values({ email }).returning();
+    if (!futureUser) throw new Error("future user insert failed");
+    try {
+      const claimed = await claimPendingInvites({
+        userId: futureUser.id,
+        email,
+      });
+      expect(claimed).toBe(1);
+      const vehicle = await getVehicle({
+        id: vehicleId,
+        userId: futureUser.id,
+      });
+      expect(vehicle?.role).toBe("member");
+    } finally {
+      await db.delete(users).where(eq(users.id, futureUser.id));
+    }
+  });
+
+  it("owner can remove a member, and the owner row is protected", async () => {
+    await removeCrewMember({
+      vehicleId,
+      userId: ownerId,
+      memberUserId: wifeId,
+    });
+    expect(await getVehicle({ id: vehicleId, userId: wifeId })).toBeNull();
+
+    // Removing the owner is a no-op
+    await removeCrewMember({
+      vehicleId,
+      userId: ownerId,
+      memberUserId: ownerId,
+    });
+    const vehicle = await getVehicle({ id: vehicleId, userId: ownerId });
+    expect(vehicle?.role).toBe("owner");
+  });
+});

--- a/app/models/member.server.ts
+++ b/app/models/member.server.ts
@@ -1,0 +1,233 @@
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+import { getDb } from "~/db/client";
+import type { User, Vehicle, VehicleInvite } from "~/db/schema";
+import { users, vehicleInvites, vehicleMembers } from "~/db/schema";
+
+export type VehicleRole = "owner" | "member";
+
+export type CrewMember = {
+  userId: string;
+  role: VehicleRole;
+  email: string;
+  displayName: string | null;
+  avatarPath: string | null;
+};
+
+export type PendingInvite = Pick<VehicleInvite, "id" | "email" | "createdAt">;
+
+/**
+ * Role of `userId` on `vehicleId`, or null if they have no access.
+ * Every vehicle-scoped read/write goes through this (or a join on
+ * vehicle_members) — never trust a vehicleId from the client alone.
+ */
+export async function getVehicleRole({
+  vehicleId,
+  userId,
+}: {
+  vehicleId: Vehicle["id"];
+  userId: User["id"];
+}): Promise<VehicleRole | null> {
+  const db = await getDb();
+  const [row] = await db
+    .select({ role: vehicleMembers.role })
+    .from(vehicleMembers)
+    .where(
+      and(
+        eq(vehicleMembers.vehicleId, vehicleId),
+        eq(vehicleMembers.userId, userId),
+      ),
+    );
+  return (row?.role as VehicleRole) ?? null;
+}
+
+export async function requireVehicleAccess({
+  vehicleId,
+  userId,
+}: {
+  vehicleId: Vehicle["id"];
+  userId: User["id"];
+}): Promise<VehicleRole> {
+  const role = await getVehicleRole({ vehicleId, userId });
+  if (!role) throw new Error("Vehicle not found");
+  return role;
+}
+
+export async function requireVehicleOwner({
+  vehicleId,
+  userId,
+}: {
+  vehicleId: Vehicle["id"];
+  userId: User["id"];
+}): Promise<void> {
+  const role = await getVehicleRole({ vehicleId, userId });
+  if (!role) throw new Error("Vehicle not found");
+  if (role !== "owner") throw new Error("Only the owner can do that");
+}
+
+export async function listCrew({
+  vehicleId,
+  userId,
+}: {
+  vehicleId: Vehicle["id"];
+  userId: User["id"];
+}): Promise<{ members: CrewMember[]; pendingInvites: PendingInvite[] }> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const members = await db
+    .select({
+      userId: vehicleMembers.userId,
+      role: vehicleMembers.role,
+      email: users.email,
+      displayName: users.displayName,
+      avatarPath: users.avatarPath,
+    })
+    .from(vehicleMembers)
+    .innerJoin(users, eq(users.id, vehicleMembers.userId))
+    .where(eq(vehicleMembers.vehicleId, vehicleId))
+    .orderBy(vehicleMembers.createdAt);
+  const pendingInvites = await db
+    .select({
+      id: vehicleInvites.id,
+      email: vehicleInvites.email,
+      createdAt: vehicleInvites.createdAt,
+    })
+    .from(vehicleInvites)
+    .where(
+      and(
+        eq(vehicleInvites.vehicleId, vehicleId),
+        isNull(vehicleInvites.acceptedAt),
+      ),
+    )
+    .orderBy(vehicleInvites.createdAt);
+  return {
+    members: members.map((m) => ({ ...m, role: m.role as VehicleRole })),
+    pendingInvites,
+  };
+}
+
+export type InviteResult =
+  | { status: "added"; email: string }
+  | { status: "invited"; email: string }
+  | { status: "already"; email: string };
+
+/**
+ * Invite an email to the crew. If a user with that email exists they're
+ * added immediately; otherwise a pending invite is stored and claimed when
+ * they sign up. Owner only.
+ */
+export async function inviteToCrew({
+  vehicleId,
+  userId,
+  email: rawEmail,
+}: {
+  vehicleId: Vehicle["id"];
+  userId: User["id"];
+  email: string;
+}): Promise<InviteResult> {
+  await requireVehicleOwner({ vehicleId, userId });
+  const email = rawEmail.trim().toLowerCase();
+  if (!email.includes("@")) throw new Error("Enter a valid email address");
+
+  const db = await getDb();
+  const [existingUser] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(sql`lower(${users.email}) = ${email}`);
+
+  if (existingUser) {
+    const existingRole = await getVehicleRole({
+      vehicleId,
+      userId: existingUser.id,
+    });
+    if (existingRole) return { status: "already", email };
+    await db
+      .insert(vehicleMembers)
+      .values({ vehicleId, userId: existingUser.id, role: "member" });
+    return { status: "added", email };
+  }
+
+  const inserted = await db
+    .insert(vehicleInvites)
+    .values({ vehicleId, email, invitedById: userId })
+    .onConflictDoNothing()
+    .returning();
+  return { status: inserted.length > 0 ? "invited" : "already", email };
+}
+
+export async function removeCrewMember({
+  vehicleId,
+  userId,
+  memberUserId,
+}: {
+  vehicleId: Vehicle["id"];
+  userId: User["id"];
+  memberUserId: User["id"];
+}): Promise<void> {
+  await requireVehicleOwner({ vehicleId, userId });
+  const db = await getDb();
+  await db.delete(vehicleMembers).where(
+    and(
+      eq(vehicleMembers.vehicleId, vehicleId),
+      eq(vehicleMembers.userId, memberUserId),
+      eq(vehicleMembers.role, "member"), // never remove the owner row
+    ),
+  );
+}
+
+export async function revokeInvite({
+  vehicleId,
+  userId,
+  inviteId,
+}: {
+  vehicleId: Vehicle["id"];
+  userId: User["id"];
+  inviteId: VehicleInvite["id"];
+}): Promise<void> {
+  await requireVehicleOwner({ vehicleId, userId });
+  const db = await getDb();
+  await db
+    .delete(vehicleInvites)
+    .where(
+      and(
+        eq(vehicleInvites.id, inviteId),
+        eq(vehicleInvites.vehicleId, vehicleId),
+      ),
+    );
+}
+
+/**
+ * Convert any pending invites for `email` into memberships. Called once at
+ * signup; safe to call repeatedly.
+ */
+export async function claimPendingInvites({
+  userId,
+  email: rawEmail,
+}: {
+  userId: User["id"];
+  email: string;
+}): Promise<number> {
+  const email = rawEmail.trim().toLowerCase();
+  const db = await getDb();
+  const pending = await db
+    .select()
+    .from(vehicleInvites)
+    .where(
+      and(eq(vehicleInvites.email, email), isNull(vehicleInvites.acceptedAt)),
+    );
+  if (pending.length === 0) return 0;
+
+  await db.transaction(async (tx) => {
+    for (const invite of pending) {
+      await tx
+        .insert(vehicleMembers)
+        .values({ vehicleId: invite.vehicleId, userId, role: "member" })
+        .onConflictDoNothing();
+      await tx
+        .update(vehicleInvites)
+        .set({ acceptedAt: new Date() })
+        .where(eq(vehicleInvites.id, invite.id));
+    }
+  });
+  return pending.length;
+}

--- a/app/models/project.server.test.ts
+++ b/app/models/project.server.test.ts
@@ -1,0 +1,117 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createDb } from "~/db/client";
+import { users } from "~/db/schema";
+import {
+  addProjectItem,
+  createProject,
+  getProject,
+  listProjects,
+  updateProjectItemStatus,
+} from "~/models/project.server";
+import { createVehicle } from "~/models/vehicle.server";
+
+const url = process.env.DATABASE_URL;
+if (!url)
+  throw new Error("DATABASE_URL is required for project.server.test.ts");
+
+const { db, close } = createDb(url);
+
+let userId: string;
+let vehicleId: string;
+
+beforeAll(async () => {
+  const [user] = await db
+    .insert(users)
+    .values({ email: `project-test-${Date.now()}@example.com` })
+    .returning();
+  if (!user) throw new Error("user insert failed");
+  userId = user.id;
+  const vehicle = await createVehicle({
+    userId,
+    make: "Test",
+    model: "Rally",
+    year: 2018,
+  });
+  vehicleId = vehicle.id;
+});
+
+afterAll(async () => {
+  await db.delete(users).where(eq(users.id, userId));
+  await close();
+});
+
+describe("projects", () => {
+  it("tracks estimated vs committed budget across item statuses", async () => {
+    const project = await createProject({
+      vehicleId,
+      userId,
+      title: "Rally prep",
+      targetDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    });
+
+    const pads = await addProjectItem({
+      vehicleId,
+      userId,
+      projectId: project.id,
+      name: "Brake pads",
+      price: 200,
+      quantity: 2,
+    });
+    await addProjectItem({
+      vehicleId,
+      userId,
+      projectId: project.id,
+      name: "Skid plate",
+      price: 350,
+      quantity: 1,
+    });
+    await addProjectItem({
+      vehicleId,
+      userId,
+      projectId: project.id,
+      name: "Mud flaps (no price yet)",
+      quantity: 4,
+    });
+
+    let [listed] = await listProjects({ vehicleId, userId });
+    expect(listed?.itemCount).toBe(3);
+    expect(listed?.estimatedTotal).toBe(750); // 200×2 + 350
+    expect(listed?.committedTotal).toBe(0); // everything still proposed
+
+    await updateProjectItemStatus({
+      id: pads.id,
+      projectId: project.id,
+      vehicleId,
+      userId,
+      status: "ordered",
+    });
+
+    [listed] = await listProjects({ vehicleId, userId });
+    expect(listed?.committedTotal).toBe(400);
+
+    const detail = await getProject({
+      id: project.id,
+      vehicleId,
+      userId,
+    });
+    expect(detail?.items).toHaveLength(3);
+    expect(detail?.items.find((i) => i.id === pads.id)?.status).toBe("ordered");
+  });
+
+  it("denies access to non-members", async () => {
+    const [stranger] = await db
+      .insert(users)
+      .values({ email: `project-stranger-${Date.now()}@example.com` })
+      .returning();
+    if (!stranger) throw new Error("stranger insert failed");
+    try {
+      await expect(
+        listProjects({ vehicleId, userId: stranger.id }),
+      ).rejects.toThrow("Vehicle not found");
+    } finally {
+      await db.delete(users).where(eq(users.id, stranger.id));
+    }
+  });
+});

--- a/app/models/project.server.ts
+++ b/app/models/project.server.ts
@@ -1,0 +1,223 @@
+import { and, desc, eq, inArray } from "drizzle-orm";
+
+import { getDb } from "~/db/client";
+import type {
+  NewProject,
+  NewProjectItem,
+  Project,
+  ProjectItem,
+} from "~/db/schema";
+import { projectItems, projects } from "~/db/schema";
+import { requireVehicleAccess } from "~/models/member.server";
+import type { ItemStatus, ProjectStatus } from "~/models/project.shared";
+
+export type { ItemStatus, Project, ProjectItem, ProjectStatus };
+
+export type ProjectListItem = Project & {
+  itemCount: number;
+  /** Sum of price × qty across all items (the full build estimate). */
+  estimatedTotal: number;
+  /** Sum across items that are ordered or further along (money committed). */
+  committedTotal: number;
+};
+
+export type ProjectWithItems = Project & { items: ProjectItem[] };
+
+function itemCost(item: Pick<ProjectItem, "price" | "quantity">): number {
+  return (item.price ?? 0) * item.quantity;
+}
+
+export async function listProjects({
+  vehicleId,
+  userId,
+}: {
+  vehicleId: Project["vehicleId"];
+  userId: string;
+}): Promise<ProjectListItem[]> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const rows = await db
+    .select()
+    .from(projects)
+    .where(eq(projects.vehicleId, vehicleId))
+    .orderBy(desc(projects.updatedAt));
+  if (rows.length === 0) return [];
+
+  const items = await db
+    .select()
+    .from(projectItems)
+    .where(
+      inArray(
+        projectItems.projectId,
+        rows.map((p) => p.id),
+      ),
+    );
+  const byProject = new Map<string, ProjectItem[]>();
+  for (const item of items) {
+    const list = byProject.get(item.projectId) ?? [];
+    list.push(item);
+    byProject.set(item.projectId, list);
+  }
+
+  return rows.map((p) => {
+    const list = byProject.get(p.id) ?? [];
+    return {
+      ...p,
+      itemCount: list.length,
+      estimatedTotal: list.reduce((sum, i) => sum + itemCost(i), 0),
+      committedTotal: list
+        .filter((i) => i.status !== "proposed")
+        .reduce((sum, i) => sum + itemCost(i), 0),
+    };
+  });
+}
+
+export async function getProject({
+  id,
+  vehicleId,
+  userId,
+}: {
+  id: Project["id"];
+  vehicleId: Project["vehicleId"];
+  userId: string;
+}): Promise<ProjectWithItems | null> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const [project] = await db
+    .select()
+    .from(projects)
+    .where(and(eq(projects.id, id), eq(projects.vehicleId, vehicleId)));
+  if (!project) return null;
+  const items = await db
+    .select()
+    .from(projectItems)
+    .where(eq(projectItems.projectId, id))
+    .orderBy(projectItems.createdAt);
+  return { ...project, items };
+}
+
+export async function createProject(
+  input: NewProject & { userId: string },
+): Promise<Project> {
+  const { userId, ...values } = input;
+  await requireVehicleAccess({ vehicleId: values.vehicleId, userId });
+  const db = await getDb();
+  const [project] = await db
+    .insert(projects)
+    .values({ ...values, createdById: userId })
+    .returning();
+  if (!project) throw new Error("Failed to create project");
+  return project;
+}
+
+export async function updateProjectStatus({
+  id,
+  vehicleId,
+  userId,
+  status,
+}: {
+  id: Project["id"];
+  vehicleId: Project["vehicleId"];
+  userId: string;
+  status: ProjectStatus;
+}): Promise<Project | null> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const [updated] = await db
+    .update(projects)
+    .set({ status })
+    .where(and(eq(projects.id, id), eq(projects.vehicleId, vehicleId)))
+    .returning();
+  return updated ?? null;
+}
+
+export async function deleteProject({
+  id,
+  vehicleId,
+  userId,
+}: {
+  id: Project["id"];
+  vehicleId: Project["vehicleId"];
+  userId: string;
+}) {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  return db
+    .delete(projects)
+    .where(and(eq(projects.id, id), eq(projects.vehicleId, vehicleId)));
+}
+
+/** Verifies the item's project belongs to a vehicle the user can access. */
+async function requireProjectAccess({
+  projectId,
+  vehicleId,
+  userId,
+}: {
+  projectId: ProjectItem["projectId"];
+  vehicleId: Project["vehicleId"];
+  userId: string;
+}) {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const [project] = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(and(eq(projects.id, projectId), eq(projects.vehicleId, vehicleId)));
+  if (!project) throw new Error("Project not found");
+}
+
+export async function addProjectItem(
+  input: NewProjectItem & { vehicleId: string; userId: string },
+): Promise<ProjectItem> {
+  const { vehicleId, userId, ...values } = input;
+  await requireProjectAccess({
+    projectId: values.projectId,
+    vehicleId,
+    userId,
+  });
+  const db = await getDb();
+  const [item] = await db.insert(projectItems).values(values).returning();
+  if (!item) throw new Error("Failed to add item");
+  return item;
+}
+
+export async function updateProjectItemStatus({
+  id,
+  projectId,
+  vehicleId,
+  userId,
+  status,
+}: {
+  id: ProjectItem["id"];
+  projectId: ProjectItem["projectId"];
+  vehicleId: Project["vehicleId"];
+  userId: string;
+  status: ItemStatus;
+}): Promise<ProjectItem | null> {
+  await requireProjectAccess({ projectId, vehicleId, userId });
+  const db = await getDb();
+  const [updated] = await db
+    .update(projectItems)
+    .set({ status })
+    .where(and(eq(projectItems.id, id), eq(projectItems.projectId, projectId)))
+    .returning();
+  return updated ?? null;
+}
+
+export async function deleteProjectItem({
+  id,
+  projectId,
+  vehicleId,
+  userId,
+}: {
+  id: ProjectItem["id"];
+  projectId: ProjectItem["projectId"];
+  vehicleId: Project["vehicleId"];
+  userId: string;
+}) {
+  await requireProjectAccess({ projectId, vehicleId, userId });
+  const db = await getDb();
+  return db
+    .delete(projectItems)
+    .where(and(eq(projectItems.id, id), eq(projectItems.projectId, projectId)));
+}

--- a/app/models/project.shared.ts
+++ b/app/models/project.shared.ts
@@ -1,0 +1,20 @@
+/**
+ * Project status vocabularies, shared between server models and client UI
+ * (status pickers render these — they can't live in a .server.ts module).
+ */
+
+export const PROJECT_STATUSES = [
+  "idea",
+  "planned",
+  "in_progress",
+  "done",
+] as const;
+export type ProjectStatus = (typeof PROJECT_STATUSES)[number];
+
+export const ITEM_STATUSES = [
+  "proposed",
+  "ordered",
+  "received",
+  "installed",
+] as const;
+export type ItemStatus = (typeof ITEM_STATUSES)[number];

--- a/app/models/reminder.server.test.ts
+++ b/app/models/reminder.server.test.ts
@@ -1,0 +1,153 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createDb } from "~/db/client";
+import { users } from "~/db/schema";
+import { createLog } from "~/models/log.server";
+import {
+  completeReminder,
+  computeReminderStatus,
+  createReminder,
+  listReminders,
+} from "~/models/reminder.server";
+import { createVehicle } from "~/models/vehicle.server";
+
+const url = process.env.DATABASE_URL;
+if (!url)
+  throw new Error("DATABASE_URL is required for reminder.server.test.ts");
+
+const { db, close } = createDb(url);
+
+let userId: string;
+let vehicleId: string;
+
+beforeAll(async () => {
+  const [user] = await db
+    .insert(users)
+    .values({ email: `reminder-test-${Date.now()}@example.com` })
+    .returning();
+  if (!user) throw new Error("user insert failed");
+  userId = user.id;
+  const vehicle = await createVehicle({
+    userId,
+    make: "Test",
+    model: "Rally",
+    year: 2018,
+  });
+  vehicleId = vehicle.id;
+});
+
+afterAll(async () => {
+  await db.delete(users).where(eq(users.id, userId));
+  await close();
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("computeReminderStatus", () => {
+  const now = new Date("2026-06-10T12:00:00Z");
+  const base = { completedAt: null, dueDate: null, dueMiles: null };
+
+  it("is overdue when the date has passed", () => {
+    const result = computeReminderStatus(
+      { ...base, dueDate: new Date(now.getTime() - 2 * DAY_MS) },
+      null,
+      now,
+    );
+    expect(result.status).toBe("overdue");
+    expect(result.daysLeft).toBeLessThanOrEqual(0);
+  });
+
+  it("is overdue when mileage has been crossed, even with a far-off date", () => {
+    const result = computeReminderStatus(
+      {
+        ...base,
+        dueDate: new Date(now.getTime() + 90 * DAY_MS),
+        dueMiles: 98000,
+      },
+      98500,
+      now,
+    );
+    expect(result.status).toBe("overdue");
+    expect(result.milesLeft).toBe(-500);
+  });
+
+  it("is due_soon within the day/mile thresholds", () => {
+    expect(
+      computeReminderStatus(
+        { ...base, dueDate: new Date(now.getTime() + 10 * DAY_MS) },
+        null,
+        now,
+      ).status,
+    ).toBe("due_soon");
+    expect(
+      computeReminderStatus({ ...base, dueMiles: 98400 }, 98000, now).status,
+    ).toBe("due_soon");
+  });
+
+  it("is ok when nothing is close, and mileage is ignored without an odometer", () => {
+    expect(
+      computeReminderStatus(
+        { ...base, dueDate: new Date(now.getTime() + 90 * DAY_MS) },
+        null,
+        now,
+      ).status,
+    ).toBe("ok");
+    expect(
+      computeReminderStatus({ ...base, dueMiles: 1 }, null, now).status,
+    ).toBe("ok");
+  });
+
+  it("is done once completed", () => {
+    expect(
+      computeReminderStatus({ ...base, completedAt: now }, null, now).status,
+    ).toBe("done");
+  });
+});
+
+describe("completeReminder", () => {
+  it("one-shot reminders get completedAt set", async () => {
+    const reminder = await createReminder({
+      vehicleId,
+      userId,
+      title: "Rally tech inspection",
+      dueDate: new Date(Date.now() + 5 * DAY_MS),
+    });
+    const updated = await completeReminder({
+      id: reminder.id,
+      vehicleId,
+      userId,
+    });
+    expect(updated?.completedAt).not.toBeNull();
+  });
+
+  it("recurring reminders roll forward from the completion odometer", async () => {
+    await createLog({
+      userId,
+      vehicleId,
+      title: "Baseline",
+      odometer: 50000,
+    });
+    const reminder = await createReminder({
+      vehicleId,
+      userId,
+      title: "Oil change",
+      dueMiles: 50500,
+      intervalMiles: 5000,
+      intervalMonths: 6,
+    });
+    const updated = await completeReminder({
+      id: reminder.id,
+      vehicleId,
+      userId,
+      odometer: 50600,
+    });
+    expect(updated?.completedAt).toBeNull(); // still active, rolled forward
+    expect(updated?.dueMiles).toBe(55600);
+    expect(updated?.dueDate).not.toBeNull();
+
+    const list = await listReminders({ vehicleId, userId });
+    const rolled = list.find((r) => r.id === reminder.id);
+    expect(rolled?.status).toBe("ok");
+  });
+});

--- a/app/models/reminder.server.ts
+++ b/app/models/reminder.server.ts
@@ -1,0 +1,197 @@
+import { and, eq } from "drizzle-orm";
+
+import { getDb } from "~/db/client";
+import type { NewReminder, Reminder } from "~/db/schema";
+import { reminders } from "~/db/schema";
+import { getLatestOdometer } from "~/models/log.server";
+import { requireVehicleAccess } from "~/models/member.server";
+
+export type { Reminder };
+
+export type ReminderStatus = "overdue" | "due_soon" | "ok" | "done";
+
+export type ReminderWithStatus = Reminder & {
+  status: ReminderStatus;
+  /** Days until dueDate; negative when past due. Null if no dueDate. */
+  daysLeft: number | null;
+  /** Miles until dueMiles based on latest logged odometer. Null if unknowable. */
+  milesLeft: number | null;
+};
+
+export const DUE_SOON_DAYS = 30;
+export const DUE_SOON_MILES = 500;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Pure status computation so it's unit-testable. A reminder is overdue if
+ * EITHER its date or mileage threshold has been crossed (whichever comes
+ * first wins — that's how service intervals work).
+ */
+export function computeReminderStatus(
+  reminder: Pick<Reminder, "dueDate" | "dueMiles" | "completedAt">,
+  currentOdometer: number | null,
+  now: Date = new Date(),
+): Pick<ReminderWithStatus, "status" | "daysLeft" | "milesLeft"> {
+  if (reminder.completedAt) {
+    return { status: "done", daysLeft: null, milesLeft: null };
+  }
+  const daysLeft =
+    reminder.dueDate != null
+      ? Math.ceil((reminder.dueDate.getTime() - now.getTime()) / DAY_MS)
+      : null;
+  const milesLeft =
+    reminder.dueMiles != null && currentOdometer != null
+      ? reminder.dueMiles - currentOdometer
+      : null;
+
+  if (
+    (daysLeft != null && daysLeft <= 0) ||
+    (milesLeft != null && milesLeft <= 0)
+  ) {
+    return { status: "overdue", daysLeft, milesLeft };
+  }
+  if (
+    (daysLeft != null && daysLeft <= DUE_SOON_DAYS) ||
+    (milesLeft != null && milesLeft <= DUE_SOON_MILES)
+  ) {
+    return { status: "due_soon", daysLeft, milesLeft };
+  }
+  return { status: "ok", daysLeft, milesLeft };
+}
+
+const STATUS_ORDER: Record<ReminderStatus, number> = {
+  overdue: 0,
+  due_soon: 1,
+  ok: 2,
+  done: 3,
+};
+
+export async function listReminders({
+  vehicleId,
+  userId,
+}: {
+  vehicleId: Reminder["vehicleId"];
+  userId: string;
+}): Promise<ReminderWithStatus[]> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const rows = await db
+    .select()
+    .from(reminders)
+    .where(eq(reminders.vehicleId, vehicleId));
+  const odometer = await getLatestOdometer({ vehicleId });
+
+  return rows
+    .map((r) => ({ ...r, ...computeReminderStatus(r, odometer) }))
+    .sort((a, b) => {
+      const byStatus = STATUS_ORDER[a.status] - STATUS_ORDER[b.status];
+      if (byStatus !== 0) return byStatus;
+      // Within a status bucket, most urgent first (fewest days, then miles).
+      const aKey = a.daysLeft ?? a.milesLeft ?? Number.MAX_SAFE_INTEGER;
+      const bKey = b.daysLeft ?? b.milesLeft ?? Number.MAX_SAFE_INTEGER;
+      return aKey - bKey;
+    });
+}
+
+export async function getReminder({
+  id,
+  vehicleId,
+  userId,
+}: {
+  id: Reminder["id"];
+  vehicleId: Reminder["vehicleId"];
+  userId: string;
+}): Promise<Reminder | null> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const [reminder] = await db
+    .select()
+    .from(reminders)
+    .where(and(eq(reminders.id, id), eq(reminders.vehicleId, vehicleId)));
+  return reminder ?? null;
+}
+
+export async function createReminder(
+  input: NewReminder & { userId: string },
+): Promise<Reminder> {
+  const { userId, ...values } = input;
+  await requireVehicleAccess({ vehicleId: values.vehicleId, userId });
+  const db = await getDb();
+  const [reminder] = await db
+    .insert(reminders)
+    .values({ ...values, createdById: userId })
+    .returning();
+  if (!reminder) throw new Error("Failed to create reminder");
+  return reminder;
+}
+
+/**
+ * Mark a reminder done. Recurring reminders (interval set) roll forward:
+ * next due date = now + intervalMonths, next due miles = the odometer at
+ * completion + intervalMiles. One-shot reminders get completedAt set.
+ */
+export async function completeReminder({
+  id,
+  vehicleId,
+  userId,
+  odometer,
+}: {
+  id: Reminder["id"];
+  vehicleId: Reminder["vehicleId"];
+  userId: string;
+  odometer?: number | null;
+}): Promise<Reminder | null> {
+  const reminder = await getReminder({ id, vehicleId, userId });
+  if (!reminder) return null;
+
+  const db = await getDb();
+  const recurring =
+    reminder.intervalMonths != null || reminder.intervalMiles != null;
+
+  if (!recurring) {
+    const [updated] = await db
+      .update(reminders)
+      .set({ completedAt: new Date() })
+      .where(eq(reminders.id, id))
+      .returning();
+    return updated ?? null;
+  }
+
+  let nextDueDate: Date | null = null;
+  if (reminder.intervalMonths != null) {
+    nextDueDate = new Date();
+    nextDueDate.setMonth(nextDueDate.getMonth() + reminder.intervalMonths);
+  }
+  let nextDueMiles: number | null = null;
+  if (reminder.intervalMiles != null) {
+    const base = odometer ?? (await getLatestOdometer({ vehicleId }));
+    nextDueMiles =
+      base != null
+        ? base + reminder.intervalMiles
+        : (reminder.dueMiles ?? 0) + reminder.intervalMiles;
+  }
+
+  const [updated] = await db
+    .update(reminders)
+    .set({ dueDate: nextDueDate, dueMiles: nextDueMiles, completedAt: null })
+    .where(eq(reminders.id, id))
+    .returning();
+  return updated ?? null;
+}
+
+export async function deleteReminder({
+  id,
+  vehicleId,
+  userId,
+}: {
+  id: Reminder["id"];
+  vehicleId: Reminder["vehicleId"];
+  userId: string;
+}) {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  return db
+    .delete(reminders)
+    .where(and(eq(reminders.id, id), eq(reminders.vehicleId, vehicleId)));
+}

--- a/app/models/vehicle.server.ts
+++ b/app/models/vehicle.server.ts
@@ -1,39 +1,138 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 
 import { getDb } from "~/db/client";
 import type { NewVehicle, Vehicle } from "~/db/schema";
-import { vehicles } from "~/db/schema";
+import { logs, reminders, vehicleMembers, vehicles } from "~/db/schema";
+import type { VehicleRole } from "~/models/member.server";
 
 export type { Vehicle };
 
+export type VehicleWithRole = Vehicle & { role: VehicleRole };
+
+/**
+ * Fetch a vehicle the user can access (owner or crew member), along with
+ * their role. Returns null when the vehicle doesn't exist or isn't shared
+ * with them — callers can't tell the difference, by design.
+ */
 export async function getVehicle({
   id,
   userId,
-}: Pick<Vehicle, "id" | "userId">) {
+}: Pick<Vehicle, "id" | "userId">): Promise<VehicleWithRole | null> {
   const db = await getDb();
-  const [vehicle] = await db
-    .select()
+  const [row] = await db
+    .select({ vehicle: vehicles, role: vehicleMembers.role })
     .from(vehicles)
-    .where(and(eq(vehicles.id, id), eq(vehicles.userId, userId)));
-  return vehicle ?? null;
+    .innerJoin(
+      vehicleMembers,
+      and(
+        eq(vehicleMembers.vehicleId, vehicles.id),
+        eq(vehicleMembers.userId, userId),
+      ),
+    )
+    .where(eq(vehicles.id, id));
+  if (!row) return null;
+  return { ...row.vehicle, role: row.role as VehicleRole };
 }
 
-export async function getVehicleListItems({ userId }: Pick<Vehicle, "userId">) {
+export type VehicleListItem = VehicleWithRole & {
+  latestOdometer: number | null;
+  overdueCount: number;
+  dueSoonCount: number;
+};
+
+const DUE_SOON_DAYS = 30;
+const DUE_SOON_MILES = 500;
+
+/**
+ * All vehicles the user owns or crews on, with the latest logged odometer
+ * and reminder alert counts for the list view badges.
+ */
+export async function getVehicleListItems({
+  userId,
+}: Pick<Vehicle, "userId">): Promise<VehicleListItem[]> {
   const db = await getDb();
-  return db
-    .select()
+  const rows = await db
+    .select({ vehicle: vehicles, role: vehicleMembers.role })
     .from(vehicles)
-    .where(eq(vehicles.userId, userId))
+    .innerJoin(
+      vehicleMembers,
+      and(
+        eq(vehicleMembers.vehicleId, vehicles.id),
+        eq(vehicleMembers.userId, userId),
+      ),
+    )
+    .where(eq(vehicleMembers.userId, userId))
     .orderBy(desc(vehicles.updatedAt));
+  if (rows.length === 0) return [];
+
+  const vehicleIds = rows.map((r) => r.vehicle.id);
+
+  const odoRows = await db
+    .select({
+      vehicleId: logs.vehicleId,
+      latestOdometer: sql<number | null>`max(${logs.odometer})`,
+    })
+    .from(logs)
+    .where(inArray(logs.vehicleId, vehicleIds))
+    .groupBy(logs.vehicleId);
+  const odoByVehicle = new Map(
+    odoRows.map((r) => [r.vehicleId, r.latestOdometer]),
+  );
+
+  const reminderRows = await db
+    .select()
+    .from(reminders)
+    .where(
+      and(
+        inArray(reminders.vehicleId, vehicleIds),
+        isNull(reminders.completedAt),
+      ),
+    );
+
+  const now = Date.now();
+  const soonCutoff = now + DUE_SOON_DAYS * 24 * 60 * 60 * 1000;
+  const alerts = new Map<string, { overdue: number; dueSoon: number }>();
+  for (const r of reminderRows) {
+    const odo = odoByVehicle.get(r.vehicleId) ?? null;
+    const overdue =
+      (r.dueDate != null && r.dueDate.getTime() <= now) ||
+      (r.dueMiles != null && odo != null && odo >= r.dueMiles);
+    const dueSoon =
+      !overdue &&
+      ((r.dueDate != null && r.dueDate.getTime() <= soonCutoff) ||
+        (r.dueMiles != null &&
+          odo != null &&
+          odo >= r.dueMiles - DUE_SOON_MILES));
+    const entry = alerts.get(r.vehicleId) ?? { overdue: 0, dueSoon: 0 };
+    if (overdue) entry.overdue += 1;
+    if (dueSoon) entry.dueSoon += 1;
+    alerts.set(r.vehicleId, entry);
+  }
+
+  return rows.map(({ vehicle, role }) => ({
+    ...vehicle,
+    role: role as VehicleRole,
+    latestOdometer: odoByVehicle.get(vehicle.id) ?? null,
+    overdueCount: alerts.get(vehicle.id)?.overdue ?? 0,
+    dueSoonCount: alerts.get(vehicle.id)?.dueSoon ?? 0,
+  }));
 }
 
 export async function createVehicle(input: NewVehicle) {
   const db = await getDb();
-  const [vehicle] = await db.insert(vehicles).values(input).returning();
-  if (!vehicle) throw new Error("Failed to create vehicle");
-  return vehicle;
+  return db.transaction(async (tx) => {
+    const [vehicle] = await tx.insert(vehicles).values(input).returning();
+    if (!vehicle) throw new Error("Failed to create vehicle");
+    await tx.insert(vehicleMembers).values({
+      vehicleId: vehicle.id,
+      userId: vehicle.userId,
+      role: "owner",
+    });
+    return vehicle;
+  });
 }
 
+/** Owner only — `userId` must match the vehicle's owner column. */
 export async function deleteVehicle({
   id,
   userId,

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -7,12 +7,19 @@ import {
 
 import stylesHref from "../styles.css?url";
 
+// Applied before paint so Garage Mode doesn't flash light on reload.
+const garageModeScript = `try{if(localStorage.getItem("garage-mode")==="1")document.documentElement.classList.add("garage")}catch(e){}`;
+
 export const Route = createRootRoute({
   head: () => ({
     meta: [
       { charSet: "utf-8" },
-      { name: "viewport", content: "width=device-width, initial-scale=1" },
+      {
+        name: "viewport",
+        content: "width=device-width, initial-scale=1, viewport-fit=cover",
+      },
       { title: "Vehicle Work Log" },
+      { name: "theme-color", content: "#0c0e11" },
     ],
     links: [{ rel: "stylesheet", href: stylesHref }],
   }),
@@ -24,8 +31,10 @@ function RootDocument() {
     <html lang="en">
       <head>
         <HeadContent />
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static inline theme script */}
+        <script dangerouslySetInnerHTML={{ __html: garageModeScript }} />
       </head>
-      <body>
+      <body className="bg-surface text-ink antialiased">
         <Outlet />
         <Scripts />
       </body>

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -18,7 +18,7 @@ export const Route = createRootRoute({
         name: "viewport",
         content: "width=device-width, initial-scale=1, viewport-fit=cover",
       },
-      { title: "Vehicle Work Log" },
+      { title: "Crew Chief" },
       { name: "theme-color", content: "#0c0e11" },
     ],
     links: [{ rel: "stylesheet", href: stylesHref }],

--- a/app/routes/_authed.tsx
+++ b/app/routes/_authed.tsx
@@ -76,8 +76,7 @@ function AuthedLayout() {
             >
               🏁
             </span>
-            <span className="hidden sm:inline">Vehicle Work Log</span>
-            <span className="sm:hidden">VWL</span>
+            <span>Crew Chief</span>
           </Link>
           <div className="flex items-center gap-2">
             <GarageModeToggle />

--- a/app/routes/_authed.tsx
+++ b/app/routes/_authed.tsx
@@ -4,7 +4,7 @@ import {
   Outlet,
   redirect,
 } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { getCurrentUserFn } from "~/auth/server-fns";
 
@@ -22,75 +22,124 @@ export const Route = createFileRoute("/_authed")({
   component: AuthedLayout,
 });
 
+function GarageModeToggle() {
+  const [on, setOn] = useState(false);
+
+  useEffect(() => {
+    setOn(document.documentElement.classList.contains("garage"));
+  }, []);
+
+  function toggle() {
+    const next = !on;
+    setOn(next);
+    document.documentElement.classList.toggle("garage", next);
+    try {
+      localStorage.setItem("garage-mode", next ? "1" : "0");
+    } catch {
+      // private browsing — theme just won't persist
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-pressed={on}
+      title="Garage Mode: high contrast + big type for the shop"
+      className={`inline-flex min-h-11 items-center gap-2 rounded-full border px-4 text-sm font-bold tracking-wide transition-colors ${
+        on
+          ? "border-accent bg-accent text-accent-ink"
+          : "border-line bg-card text-ink-muted hover:text-ink"
+      }`}
+    >
+      <span aria-hidden>🔧</span>
+      <span className="hidden sm:inline">GARAGE</span>
+    </button>
+  );
+}
+
 function AuthedLayout() {
   const { user } = Route.useRouteContext();
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      <header className="border-b border-slate-200 bg-white">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-          <Link to="/vehicles" className="font-semibold text-slate-900">
-            Vehicle Work Log
-          </Link>
-          <div className="relative">
-            <button
-              type="button"
-              onClick={() => setMenuOpen((v) => !v)}
-              className="flex items-center gap-2 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+    <div className="min-h-screen bg-surface">
+      <header className="sticky top-0 z-20 border-b border-line bg-card/95 backdrop-blur">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-3 sm:px-6">
+          <Link
+            to="/vehicles"
+            className="flex items-center gap-2 font-bold text-ink"
+          >
+            <span
+              aria-hidden
+              className="flex h-9 w-9 items-center justify-center rounded-xl bg-accent text-lg text-accent-ink"
             >
-              {user.avatarPath ? (
-                <img
-                  src={`/files/${user.avatarPath}`}
-                  alt=""
-                  className="h-8 w-8 rounded-full object-cover"
-                />
-              ) : (
-                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-200 text-sm font-medium text-slate-600">
-                  {(user.displayName ?? user.email)[0]?.toUpperCase()}
-                </span>
-              )}
-            </button>
-            {menuOpen ? (
-              <>
-                <button
-                  type="button"
-                  className="fixed inset-0 cursor-default"
-                  onClick={() => setMenuOpen(false)}
-                  aria-label="Close menu"
-                  tabIndex={-1}
-                />
-                <div className="absolute right-0 z-10 mt-2 w-48 rounded-md border border-slate-200 bg-white py-1 shadow-lg">
-                  <div className="border-b border-slate-100 px-4 py-2">
-                    <p className="truncate text-sm font-medium text-slate-900">
-                      {user.displayName ?? user.email}
-                    </p>
-                    {user.displayName ? (
-                      <p className="truncate text-xs text-slate-500">
-                        {user.email}
-                      </p>
-                    ) : null}
-                  </div>
-                  <Link
-                    to="/profile"
-                    className="block px-4 py-2 text-sm text-slate-700 hover:bg-slate-50"
+              🏁
+            </span>
+            <span className="hidden sm:inline">Vehicle Work Log</span>
+            <span className="sm:hidden">VWL</span>
+          </Link>
+          <div className="flex items-center gap-2">
+            <GarageModeToggle />
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setMenuOpen((v) => !v)}
+                className="flex items-center gap-2 rounded-full focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2"
+              >
+                {user.avatarPath ? (
+                  <img
+                    src={`/files/${user.avatarPath}`}
+                    alt=""
+                    className="h-10 w-10 rounded-full object-cover"
+                  />
+                ) : (
+                  <span className="flex h-10 w-10 items-center justify-center rounded-full bg-sunken text-sm font-medium text-ink">
+                    {(user.displayName ?? user.email)[0]?.toUpperCase()}
+                  </span>
+                )}
+              </button>
+              {menuOpen ? (
+                <>
+                  <button
+                    type="button"
+                    className="fixed inset-0 cursor-default"
                     onClick={() => setMenuOpen(false)}
-                  >
-                    Profile
-                  </Link>
-                  <a
-                    href="/logout"
-                    className="block px-4 py-2 text-sm text-slate-700 hover:bg-slate-50"
-                  >
-                    Log out
-                  </a>
-                </div>
-              </>
-            ) : null}
+                    aria-label="Close menu"
+                    tabIndex={-1}
+                  />
+                  <div className="absolute right-0 z-10 mt-2 w-56 rounded-xl border border-line bg-card py-1 shadow-lg">
+                    <div className="border-b border-line px-4 py-2">
+                      <p className="truncate text-sm font-medium text-ink">
+                        {user.displayName ?? user.email}
+                      </p>
+                      {user.displayName ? (
+                        <p className="truncate text-xs text-ink-muted">
+                          {user.email}
+                        </p>
+                      ) : null}
+                    </div>
+                    <Link
+                      to="/profile"
+                      className="block px-4 py-3 text-sm text-ink hover:bg-sunken"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      Profile
+                    </Link>
+                    <a
+                      href="/logout"
+                      className="block px-4 py-3 text-sm text-ink hover:bg-sunken"
+                    >
+                      Log out
+                    </a>
+                  </div>
+                </>
+              ) : null}
+            </div>
           </div>
         </div>
       </header>
-      <main className="mx-auto max-w-5xl px-6 py-8">
+      <main className="mx-auto max-w-5xl px-4 py-6 pb-16 sm:px-6 sm:py-8">
         <Outlet />
       </main>
     </div>

--- a/app/routes/_authed.vehicles.$vehicleId.index.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.index.tsx
@@ -6,11 +6,77 @@ import {
   useRouter,
 } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
+import { useState } from "react";
 
 import { requireAuth } from "~/auth/session.server";
+import { statusBadgeClass, statusLabel } from "~/components/reminder-display";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  errorBox,
+  input,
+} from "~/components/ui";
+import { getLatestOdometer, getLogListItems } from "~/models/log.server";
+import {
+  inviteToCrew,
+  listCrew,
+  removeCrewMember,
+  revokeInvite,
+} from "~/models/member.server";
+import { listProjects } from "~/models/project.server";
+import { listReminders } from "~/models/reminder.server";
 import { deleteVehicle } from "~/models/vehicle.server";
 
 const parentApi = getRouteApi("/_authed/vehicles/$vehicleId");
+
+const loadDashboardFn = createServerFn({ method: "GET" })
+  .inputValidator((vehicleId: string) => vehicleId)
+  .handler(async ({ data: vehicleId }) => {
+    const userId = await requireAuth();
+    const [reminders, recentLogs, projects, crew, odometer] = await Promise.all(
+      [
+        listReminders({ vehicleId, userId }),
+        getLogListItems({ vehicleId, userId, limit: 4 }),
+        listProjects({ vehicleId, userId }),
+        listCrew({ vehicleId, userId }),
+        getLatestOdometer({ vehicleId }),
+      ],
+    );
+    return {
+      nextUp: reminders.filter((r) => r.status !== "done").slice(0, 3),
+      recentLogs,
+      activeProjects: projects.filter((p) => p.status !== "done").slice(0, 3),
+      crew,
+      odometer,
+      userId,
+    };
+  });
+
+const inviteFn = createServerFn({ method: "POST" })
+  .inputValidator((data: { vehicleId: string; email: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    try {
+      return await inviteToCrew({ ...data, userId });
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : "Invite failed" };
+    }
+  });
+
+const removeMemberFn = createServerFn({ method: "POST" })
+  .inputValidator((data: { vehicleId: string; memberUserId: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await removeCrewMember({ ...data, userId });
+  });
+
+const revokeInviteFn = createServerFn({ method: "POST" })
+  .inputValidator((data: { vehicleId: string; inviteId: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await revokeInvite({ ...data, userId });
+  });
 
 const deleteVehicleFn = createServerFn({ method: "POST" })
   .inputValidator((vehicleId: string) => vehicleId)
@@ -20,55 +86,351 @@ const deleteVehicleFn = createServerFn({ method: "POST" })
   });
 
 export const Route = createFileRoute("/_authed/vehicles/$vehicleId/")({
-  component: VehicleDetail,
+  component: VehicleDashboard,
+  loader: async ({ params }) => loadDashboardFn({ data: params.vehicleId }),
 });
 
-function VehicleDetail() {
+function SectionCard({
+  title,
+  action,
+  children,
+}: {
+  title: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={`${card} p-5`}>
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-bold text-ink">{title}</h2>
+        {action}
+      </div>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+function daysUntil(date: Date): number {
+  return Math.ceil((date.getTime() - Date.now()) / (24 * 60 * 60 * 1000));
+}
+
+function CrewCard({
+  vehicleId,
+  isOwner,
+  userId,
+  crew,
+}: {
+  vehicleId: string;
+  isOwner: boolean;
+  userId: string;
+  crew: Awaited<ReturnType<typeof listCrew>>;
+}) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onInvite(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+    setPending(true);
+    try {
+      const result = await inviteFn({ data: { vehicleId, email } });
+      if ("error" in result) {
+        setError(result.error ?? "Invite failed");
+      } else if (result.status === "added") {
+        setMessage(`${result.email} added to the crew`);
+        setEmail("");
+      } else if (result.status === "invited") {
+        setMessage(
+          `Invite saved — ${result.email} joins the crew when they sign up`,
+        );
+        setEmail("");
+      } else {
+        setMessage(`${result.email} is already on the crew`);
+      }
+      await router.invalidate();
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <SectionCard title="Crew">
+      <ul className="space-y-2">
+        {crew.members.map((m) => (
+          <li key={m.userId} className="flex items-center gap-3">
+            {m.avatarPath ? (
+              <img
+                src={`/files/${m.avatarPath}`}
+                alt=""
+                className="h-9 w-9 rounded-full object-cover"
+              />
+            ) : (
+              <span className="flex h-9 w-9 items-center justify-center rounded-full bg-sunken text-sm font-medium text-ink">
+                {(m.displayName ?? m.email)[0]?.toUpperCase()}
+              </span>
+            )}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold text-ink">
+                {m.displayName ?? m.email}
+                {m.userId === userId ? " (you)" : ""}
+              </p>
+              <p className="text-xs text-ink-muted">{m.role}</p>
+            </div>
+            {isOwner && m.role !== "owner" ? (
+              <button
+                type="button"
+                className="text-xs font-semibold text-danger hover:underline"
+                onClick={async () => {
+                  if (!window.confirm(`Remove ${m.displayName ?? m.email}?`))
+                    return;
+                  await removeMemberFn({
+                    data: { vehicleId, memberUserId: m.userId },
+                  });
+                  await router.invalidate();
+                }}
+              >
+                Remove
+              </button>
+            ) : null}
+          </li>
+        ))}
+        {crew.pendingInvites.map((invite) => (
+          <li key={invite.id} className="flex items-center gap-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-line text-sm text-ink-muted">
+              ?
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm text-ink">{invite.email}</p>
+              <p className="text-xs text-ink-muted">
+                invited — not signed up yet
+              </p>
+            </div>
+            {isOwner ? (
+              <button
+                type="button"
+                className="text-xs font-semibold text-danger hover:underline"
+                onClick={async () => {
+                  await revokeInviteFn({
+                    data: { vehicleId, inviteId: invite.id },
+                  });
+                  await router.invalidate();
+                }}
+              >
+                Revoke
+              </button>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+      {isOwner ? (
+        <form onSubmit={onInvite} className="mt-4">
+          <div className="flex gap-2">
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="steph@example.com"
+              aria-label="Email to invite"
+              className={`${input} mt-0 flex-1`}
+            />
+            <button type="submit" disabled={pending} className={btnSecondary}>
+              Invite
+            </button>
+          </div>
+          {message ? <p className="mt-2 text-sm text-ok">{message}</p> : null}
+          {error ? <p className={`${errorBox} mt-2`}>{error}</p> : null}
+        </form>
+      ) : null}
+    </SectionCard>
+  );
+}
+
+function VehicleDashboard() {
   const router = useRouter();
   const navigate = useNavigate();
   const v = parentApi.useLoaderData();
+  const data = Route.useLoaderData();
+  const isOwner = v.role === "owner";
 
   async function onDelete() {
-    if (!window.confirm(`Delete ${v.year} ${v.make} ${v.model}?`)) return;
+    if (
+      !window.confirm(
+        `Delete ${v.year} ${v.make} ${v.model}? This removes all logs, reminders, and projects.`,
+      )
+    )
+      return;
     await deleteVehicleFn({ data: v.id });
     await router.invalidate();
     navigate({ to: "/vehicles" });
   }
 
   return (
-    <section>
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold text-slate-900">
-            {v.year} {v.make} {v.model}
-            {v.trim ? ` ${v.trim}` : ""}
-          </h1>
-          {v.name ? <p className="mt-1 text-slate-600">“{v.name}”</p> : null}
-          {v.avatarPath ? (
-            <img
-              src={`/files/${v.avatarPath}`}
-              alt={`${v.make} ${v.model}`}
-              className="mt-4 h-48 w-auto rounded-lg object-cover"
-            />
-          ) : null}
-        </div>
-        <button
-          type="button"
-          onClick={onDelete}
-          className="text-sm text-red-600 hover:underline"
-        >
-          Delete vehicle
-        </button>
-      </div>
-      <div className="mt-8">
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
         <Link
-          to="/vehicles/$vehicleId/logs"
+          to="/vehicles/$vehicleId/logs/new"
           params={{ vehicleId: v.id }}
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+          className={`${btnPrimary} flex-1 py-4 text-lg sm:flex-none sm:px-8`}
         >
-          View service logs
+          🔧 Log work
         </Link>
+        <div className={`${card} flex items-center gap-3 px-5 py-3`}>
+          <span className="text-xs font-bold uppercase tracking-wide text-ink-muted">
+            Odometer
+          </span>
+          <span className="text-xl font-bold tabular-nums text-ink">
+            {data.odometer != null
+              ? `${Math.round(data.odometer).toLocaleString()} mi`
+              : "—"}
+          </span>
+        </div>
       </div>
-    </section>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <SectionCard
+          title="Next up"
+          action={
+            <Link
+              to="/vehicles/$vehicleId/reminders"
+              params={{ vehicleId: v.id }}
+              className="text-sm font-semibold text-accent hover:underline"
+            >
+              All reminders →
+            </Link>
+          }
+        >
+          {data.nextUp.length === 0 ? (
+            <p className="text-sm text-ink-muted">
+              Nothing scheduled. Add reminders for oil, brakes, tires — they
+              track both date and mileage.
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {data.nextUp.map((r) => (
+                <li
+                  key={r.id}
+                  className="flex items-center justify-between gap-3"
+                >
+                  <span className="min-w-0 truncate font-medium text-ink">
+                    {r.title}
+                  </span>
+                  <span className={statusBadgeClass(r.status)}>
+                    {statusLabel(r)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </SectionCard>
+
+        <SectionCard
+          title="Builds & plans"
+          action={
+            <Link
+              to="/vehicles/$vehicleId/projects"
+              params={{ vehicleId: v.id }}
+              className="text-sm font-semibold text-accent hover:underline"
+            >
+              All projects →
+            </Link>
+          }
+        >
+          {data.activeProjects.length === 0 ? (
+            <p className="text-sm text-ink-muted">
+              No active projects. Plan the next build — parts, prices, and a
+              countdown to event day.
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {data.activeProjects.map((p) => (
+                <li key={p.id}>
+                  <Link
+                    to="/vehicles/$vehicleId/projects/$projectId"
+                    params={{ vehicleId: v.id, projectId: p.id }}
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <span className="min-w-0 truncate font-medium text-ink">
+                      {p.title}
+                    </span>
+                    <span className="shrink-0 text-xs font-semibold text-ink-muted">
+                      {p.targetDate
+                        ? daysUntil(p.targetDate) >= 0
+                          ? `${daysUntil(p.targetDate)}d out`
+                          : "past due"
+                        : `${p.itemCount} items`}
+                      {p.estimatedTotal > 0
+                        ? ` · $${Math.round(p.estimatedTotal).toLocaleString()}`
+                        : ""}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </SectionCard>
+
+        <SectionCard
+          title="Recent work"
+          action={
+            <Link
+              to="/vehicles/$vehicleId/logs"
+              params={{ vehicleId: v.id }}
+              className="text-sm font-semibold text-accent hover:underline"
+            >
+              All logs →
+            </Link>
+          }
+        >
+          {data.recentLogs.length === 0 ? (
+            <p className="text-sm text-ink-muted">No work logged yet.</p>
+          ) : (
+            <ul className="space-y-3">
+              {data.recentLogs.map((log) => (
+                <li key={log.id}>
+                  <Link
+                    to="/vehicles/$vehicleId/logs/$logId"
+                    params={{ vehicleId: v.id, logId: log.id }}
+                    className="block"
+                  >
+                    <span className="font-medium text-ink">{log.title}</span>
+                    <span className="mt-0.5 block text-xs text-ink-muted">
+                      {log.servicedAt.toLocaleDateString()}
+                      {log.odometer != null
+                        ? ` · ${Math.round(log.odometer).toLocaleString()} mi`
+                        : ""}
+                      {log.authorName ? ` · ${log.authorName}` : ""}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </SectionCard>
+
+        <CrewCard
+          vehicleId={v.id}
+          isOwner={isOwner}
+          userId={data.userId}
+          crew={data.crew}
+        />
+      </div>
+
+      {isOwner ? (
+        <div className="pt-4 text-right">
+          <button
+            type="button"
+            onClick={onDelete}
+            className="text-sm text-danger hover:underline"
+          >
+            Delete vehicle
+          </button>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/app/routes/_authed.vehicles.$vehicleId.logs.$logId.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.logs.$logId.tsx
@@ -8,6 +8,7 @@ import {
 import { createServerFn } from "@tanstack/react-start";
 
 import { requireAuth } from "~/auth/session.server";
+import { card } from "~/components/ui";
 import { deleteLog, getLog } from "~/models/log.server";
 
 const loadLogFn = createServerFn({ method: "GET" })
@@ -56,44 +57,49 @@ function LogDetail() {
 
   return (
     <section>
-      <div className="flex items-start justify-between">
+      <div className="flex items-start justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-semibold text-slate-900">{log.title}</h1>
-          <div className="mt-1 text-sm text-slate-500">
+          <h2 className="text-xl font-bold text-ink">{log.title}</h2>
+          <div className="mt-1 text-sm text-ink-muted">
             {log.servicedAt.toLocaleDateString()}
             {log.type ? ` · ${log.type}` : ""}
+            {log.authorName ? ` · logged by ${log.authorName}` : ""}
           </div>
         </div>
         <button
           type="button"
           onClick={onDelete}
-          className="text-sm text-red-600 hover:underline"
+          className="shrink-0 text-sm text-danger hover:underline"
         >
           Delete
         </button>
       </div>
       {log.notes ? (
-        <p className="mt-4 whitespace-pre-wrap text-slate-700">{log.notes}</p>
+        <p className="mt-4 whitespace-pre-wrap text-ink">{log.notes}</p>
       ) : null}
-      <dl className="mt-6 grid grid-cols-2 gap-4 text-sm">
-        {log.odometer != null ? (
-          <div>
-            <dt className="text-slate-500">Odometer</dt>
-            <dd className="text-slate-900">{log.odometer.toLocaleString()}</dd>
-          </div>
-        ) : null}
-        {log.cost != null ? (
-          <div>
-            <dt className="text-slate-500">Cost</dt>
-            <dd className="text-slate-900">${log.cost.toFixed(2)}</dd>
-          </div>
-        ) : null}
-        {log.selfService ? (
-          <div>
-            <dt className="text-slate-500">Self-service</dt>
-            <dd className="text-slate-900">Yes</dd>
-          </div>
-        ) : null}
+      <dl
+        className={`${card} mt-6 grid grid-cols-2 gap-4 p-5 text-sm sm:grid-cols-3`}
+      >
+        <div>
+          <dt className="text-ink-muted">Odometer</dt>
+          <dd className="mt-0.5 font-semibold tabular-nums text-ink">
+            {log.odometer != null
+              ? `${Math.round(log.odometer).toLocaleString()} mi`
+              : "—"}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-ink-muted">Cost</dt>
+          <dd className="mt-0.5 font-semibold tabular-nums text-ink">
+            {log.cost != null ? `$${log.cost.toFixed(2)}` : "—"}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-ink-muted">Who did it</dt>
+          <dd className="mt-0.5 font-semibold text-ink">
+            {log.selfService ? "DIY 🔧" : "Shop"}
+          </dd>
+        </div>
       </dl>
     </section>
   );

--- a/app/routes/_authed.vehicles.$vehicleId.logs.index.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.logs.index.tsx
@@ -5,6 +5,8 @@ import {
   useParams,
 } from "@tanstack/react-router";
 
+import { btnPrimary, card } from "~/components/ui";
+
 const logsApi = getRouteApi("/_authed/vehicles/$vehicleId/logs");
 
 export const Route = createFileRoute("/_authed/vehicles/$vehicleId/logs/")({
@@ -18,34 +20,48 @@ function LogsList() {
   const logs = logsApi.useLoaderData();
   return (
     <section>
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-slate-900">Service logs</h2>
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-xl font-bold text-ink">Work history</h2>
         <Link
           to="/vehicles/$vehicleId/logs/new"
           params={{ vehicleId }}
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+          className={btnPrimary}
         >
-          Add log
+          + Log work
         </Link>
       </div>
       {logs.length === 0 ? (
-        <p className="mt-6 text-slate-600">No logs yet.</p>
+        <p className="mt-6 text-sm text-ink-muted">
+          Nothing logged yet — hit “Log work” after the next job.
+        </p>
       ) : (
-        <ul className="mt-6 divide-y divide-slate-200 rounded-xl border border-slate-200 bg-white">
+        <ul className={`${card} mt-6 divide-y divide-line`}>
           {logs.map((log) => (
-            <li key={log.id} className="p-4">
+            <li key={log.id}>
               <Link
                 to="/vehicles/$vehicleId/logs/$logId"
                 params={{ vehicleId, logId: log.id }}
-                className="block"
+                className="block p-4 hover:bg-sunken"
               >
-                <div className="font-medium text-slate-900">{log.title}</div>
-                <div className="mt-1 text-xs text-slate-500">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="font-semibold text-ink">{log.title}</span>
+                  {log.cost != null ? (
+                    <span className="shrink-0 text-sm font-semibold tabular-nums text-ink-muted">
+                      $
+                      {log.cost.toLocaleString(undefined, {
+                        maximumFractionDigits: 2,
+                      })}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="mt-1 text-xs text-ink-muted">
                   {log.servicedAt.toLocaleDateString()}
                   {log.type ? ` · ${log.type}` : ""}
                   {log.odometer != null
-                    ? ` · ${log.odometer.toLocaleString()} mi`
+                    ? ` · ${Math.round(log.odometer).toLocaleString()} mi`
                     : ""}
+                  {log.authorName ? ` · ${log.authorName}` : ""}
+                  {log.selfService ? " · DIY" : ""}
                 </div>
               </Link>
             </li>

--- a/app/routes/_authed.vehicles.$vehicleId.logs.new.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.logs.new.tsx
@@ -7,7 +7,44 @@ import { createServerFn } from "@tanstack/react-start";
 import { useState } from "react";
 
 import { requireAuth } from "~/auth/session.server";
+import {
+  btnPrimary,
+  card,
+  chip,
+  errorBox,
+  input,
+  label,
+  textarea,
+} from "~/components/ui";
 import { createLog } from "~/models/log.server";
+import { completeReminder, getReminder } from "~/models/reminder.server";
+
+// Tap-to-fill presets so common jobs don't need typing in the shop.
+const PRESETS = [
+  "Oil change",
+  "Brake pads",
+  "Tire rotation",
+  "New tires",
+  "Air filter",
+  "Coolant",
+  "Battery",
+  "Wipers",
+  "Alignment",
+  "Inspection",
+] as const;
+
+const TYPES = ["Minor", "Major", "Modify", "Check"] as const;
+
+const loadReminderFn = createServerFn({ method: "GET" })
+  .inputValidator((data: { vehicleId: string; reminderId: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    return getReminder({
+      id: data.reminderId,
+      vehicleId: data.vehicleId,
+      userId,
+    });
+  });
 
 const createLogFn = createServerFn({ method: "POST" })
   .inputValidator((data: FormData) => data)
@@ -22,6 +59,7 @@ const createLogFn = createServerFn({ method: "POST" })
     const odometerRaw = String(data.get("odometer") ?? "").trim();
     const servicedAtRaw = String(data.get("servicedAt") ?? "").trim();
     const selfService = data.get("selfService") === "on";
+    const reminderId = String(data.get("reminderId") ?? "").trim() || null;
 
     if (!title || !vehicleId) {
       return { error: "Title is required" as const };
@@ -43,10 +81,29 @@ const createLogFn = createServerFn({ method: "POST" })
       selfService,
     });
 
+    // Logging the work knocks out the reminder that prompted it —
+    // recurring reminders roll forward from this odometer reading.
+    if (reminderId) {
+      await completeReminder({ id: reminderId, vehicleId, userId, odometer });
+    }
+
     return { vehicleId, logId: log.id };
   });
 
+type LogSearch = { reminder?: string };
+
 export const Route = createFileRoute("/_authed/vehicles/$vehicleId/logs/new")({
+  validateSearch: (search: Record<string, unknown>): LogSearch => ({
+    reminder: typeof search.reminder === "string" ? search.reminder : undefined,
+  }),
+  loaderDeps: ({ search }) => ({ reminder: search.reminder }),
+  loader: async ({ params, deps }) => {
+    if (!deps.reminder) return { reminder: null };
+    const reminder = await loadReminderFn({
+      data: { vehicleId: params.vehicleId, reminderId: deps.reminder },
+    });
+    return { reminder };
+  },
   component: NewLog,
 });
 
@@ -55,6 +112,9 @@ function NewLog() {
   const { vehicleId } = useParams({
     from: "/_authed/vehicles/$vehicleId/logs/new",
   });
+  const { reminder } = Route.useLoaderData();
+  const [title, setTitle] = useState(reminder?.title ?? "");
+  const [type, setType] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
@@ -64,14 +124,17 @@ function NewLog() {
     setPending(true);
     const formData = new FormData(e.currentTarget);
     formData.set("vehicleId", vehicleId);
+    formData.set("title", title);
+    formData.set("type", type);
+    if (reminder) formData.set("reminderId", reminder.id);
     try {
       const result = await createLogFn({ data: formData });
       if (result && "error" in result && result.error) {
         setError(result.error);
       } else if (result && "logId" in result) {
         navigate({
-          to: "/vehicles/$vehicleId/logs/$logId",
-          params: { vehicleId: result.vehicleId, logId: result.logId },
+          to: "/vehicles/$vehicleId",
+          params: { vehicleId: result.vehicleId },
         });
       }
     } catch (err) {
@@ -82,81 +145,115 @@ function NewLog() {
   }
 
   return (
-    <section>
-      <h1 className="text-2xl font-semibold text-slate-900">New service log</h1>
-      <form onSubmit={onSubmit} className="mt-6 max-w-lg space-y-4">
-        {error ? (
-          <p className="rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
-            {error}
-          </p>
-        ) : null}
-        <label className="block text-sm font-medium text-slate-700">
-          Title
+    <section className="mx-auto max-w-lg">
+      <h2 className="text-xl font-bold text-ink">Log work</h2>
+      {reminder ? (
+        <p className="mt-1 text-sm text-ink-muted">
+          Knocking out the “{reminder.title}” reminder — saving this log marks
+          it done{" "}
+          {reminder.intervalMonths != null || reminder.intervalMiles != null
+            ? "and schedules the next one"
+            : ""}
+          .
+        </p>
+      ) : null}
+      <form onSubmit={onSubmit} className="mt-4 space-y-5">
+        {error ? <p className={errorBox}>{error}</p> : null}
+
+        <div>
+          <span className={label}>What did you do?</span>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {PRESETS.map((preset) => (
+              <button
+                key={preset}
+                type="button"
+                className={chip(title === preset)}
+                onClick={() => setTitle(preset)}
+              >
+                {preset}
+              </button>
+            ))}
+          </div>
           <input
-            name="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
             required
-            className="mt-1 w-full rounded border border-slate-300 p-2"
+            placeholder="…or type it"
+            aria-label="Title"
+            className={`${input} mt-3 text-lg font-semibold`}
           />
+        </div>
+
+        <div className={`${card} p-4`}>
+          <div className="grid grid-cols-2 gap-3">
+            <label className={label}>
+              Odometer (mi)
+              <input
+                name="odometer"
+                type="number"
+                step="1"
+                inputMode="numeric"
+                placeholder="98 412"
+                className={`${input} text-lg font-semibold tabular-nums`}
+              />
+            </label>
+            <label className={label}>
+              Cost (USD)
+              <input
+                name="cost"
+                type="number"
+                step="0.01"
+                inputMode="decimal"
+                placeholder="64.99"
+                className={`${input} text-lg font-semibold tabular-nums`}
+              />
+            </label>
+          </div>
+        </div>
+
+        <div>
+          <span className={label}>Job size</span>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {TYPES.map((t) => (
+              <button
+                key={t}
+                type="button"
+                className={chip(type === t)}
+                onClick={() => setType(type === t ? "" : t)}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <label className={label}>
+          Notes — torque specs, part numbers, what you'd do differently
+          <textarea name="notes" rows={4} className={textarea} />
         </label>
-        <label className="block text-sm font-medium text-slate-700">
-          Notes
-          <textarea
-            name="notes"
-            rows={4}
-            className="mt-1 w-full rounded border border-slate-300 p-2"
-          />
-        </label>
-        <label className="block text-sm font-medium text-slate-700">
-          Type
-          <select
-            name="type"
-            className="mt-1 w-full rounded border border-slate-300 p-2"
-          >
-            <option value="">—</option>
-            <option>Minor</option>
-            <option>Major</option>
-            <option>Modify</option>
-            <option>Check</option>
-          </select>
-        </label>
-        <div className="grid grid-cols-2 gap-3">
-          <label className="block text-sm font-medium text-slate-700">
-            Cost (USD)
-            <input
-              name="cost"
-              type="number"
-              step="0.01"
-              className="mt-1 w-full rounded border border-slate-300 p-2"
-            />
+
+        <div className="grid grid-cols-2 items-end gap-3">
+          <label className={label}>
+            When
+            <input name="servicedAt" type="date" className={input} />
           </label>
-          <label className="block text-sm font-medium text-slate-700">
-            Odometer
+          <label className="flex min-h-11 items-center gap-3 text-sm font-medium text-ink">
             <input
-              name="odometer"
-              type="number"
-              step="1"
-              className="mt-1 w-full rounded border border-slate-300 p-2"
+              type="checkbox"
+              name="selfService"
+              defaultChecked
+              className="h-6 w-6 rounded accent-(--app-accent)"
             />
+            We did it ourselves
           </label>
         </div>
-        <label className="block text-sm font-medium text-slate-700">
-          Serviced at
-          <input
-            name="servicedAt"
-            type="date"
-            className="mt-1 w-full rounded border border-slate-300 p-2"
-          />
-        </label>
-        <label className="flex items-center gap-2 text-sm text-slate-700">
-          <input type="checkbox" name="selfService" />
-          Self-service
-        </label>
+
         <button
           type="submit"
           disabled={pending}
-          className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+          className={`${btnPrimary} w-full py-4 text-lg`}
         >
-          {pending ? "Saving…" : "Save log"}
+          {pending ? "Saving…" : "Save it ✓"}
         </button>
       </form>
     </section>

--- a/app/routes/_authed.vehicles.$vehicleId.projects.$projectId.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.projects.$projectId.tsx
@@ -1,0 +1,415 @@
+import {
+  createFileRoute,
+  notFound,
+  useNavigate,
+  useParams,
+  useRouter,
+} from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { useState } from "react";
+
+import { requireAuth } from "~/auth/session.server";
+import { btnSecondary, card, errorBox, input, label } from "~/components/ui";
+import {
+  addProjectItem,
+  deleteProject,
+  deleteProjectItem,
+  getProject,
+  updateProjectItemStatus,
+  updateProjectStatus,
+} from "~/models/project.server";
+import type { ItemStatus, ProjectStatus } from "~/models/project.shared";
+import { ITEM_STATUSES, PROJECT_STATUSES } from "~/models/project.shared";
+
+const loadProjectFn = createServerFn({ method: "GET" })
+  .inputValidator((data: { vehicleId: string; projectId: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    return getProject({
+      id: data.projectId,
+      vehicleId: data.vehicleId,
+      userId,
+    });
+  });
+
+const setProjectStatusFn = createServerFn({ method: "POST" })
+  .inputValidator(
+    (data: { vehicleId: string; projectId: string; status: ProjectStatus }) =>
+      data,
+  )
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await updateProjectStatus({
+      id: data.projectId,
+      vehicleId: data.vehicleId,
+      userId,
+      status: data.status,
+    });
+  });
+
+const deleteProjectFn = createServerFn({ method: "POST" })
+  .inputValidator((data: { vehicleId: string; projectId: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await deleteProject({
+      id: data.projectId,
+      vehicleId: data.vehicleId,
+      userId,
+    });
+  });
+
+const addItemFn = createServerFn({ method: "POST" })
+  .inputValidator((data: FormData) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    const vehicleId = String(data.get("vehicleId") ?? "");
+    const projectId = String(data.get("projectId") ?? "");
+    const name = String(data.get("name") ?? "").trim();
+    if (!name) return { error: "Part name is required" as const };
+    const priceRaw = String(data.get("price") ?? "").trim();
+    const qtyRaw = String(data.get("quantity") ?? "").trim();
+    await addProjectItem({
+      vehicleId,
+      userId,
+      projectId,
+      name,
+      url: String(data.get("url") ?? "").trim() || null,
+      price: priceRaw ? Number.parseFloat(priceRaw) : null,
+      quantity: qtyRaw ? Number.parseInt(qtyRaw, 10) : 1,
+    });
+    return { ok: true as const };
+  });
+
+const setItemStatusFn = createServerFn({ method: "POST" })
+  .inputValidator(
+    (data: {
+      vehicleId: string;
+      projectId: string;
+      itemId: string;
+      status: ItemStatus;
+    }) => data,
+  )
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await updateProjectItemStatus({
+      id: data.itemId,
+      projectId: data.projectId,
+      vehicleId: data.vehicleId,
+      userId,
+      status: data.status,
+    });
+  });
+
+const deleteItemFn = createServerFn({ method: "POST" })
+  .inputValidator(
+    (data: { vehicleId: string; projectId: string; itemId: string }) => data,
+  )
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await deleteProjectItem({
+      id: data.itemId,
+      projectId: data.projectId,
+      vehicleId: data.vehicleId,
+      userId,
+    });
+  });
+
+export const Route = createFileRoute(
+  "/_authed/vehicles/$vehicleId/projects/$projectId",
+)({
+  component: ProjectDetail,
+  loader: async ({ params }) => {
+    const project =
+      (await loadProjectFn({
+        data: { vehicleId: params.vehicleId, projectId: params.projectId },
+      })) ?? null;
+    if (!project) throw notFound();
+    return project;
+  },
+});
+
+const PROJECT_STATUS_LABELS: Record<ProjectStatus, string> = {
+  idea: "💡 Idea",
+  planned: "📋 Planned",
+  in_progress: "🔧 In progress",
+  done: "✅ Done",
+};
+
+const ITEM_STATUS_LABELS: Record<ItemStatus, string> = {
+  proposed: "proposed",
+  ordered: "ordered",
+  received: "received",
+  installed: "installed",
+};
+
+function daysUntil(date: Date): number {
+  return Math.ceil((date.getTime() - Date.now()) / (24 * 60 * 60 * 1000));
+}
+
+function AddItemForm({
+  vehicleId,
+  projectId,
+}: {
+  vehicleId: string;
+  projectId: string;
+}) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setPending(true);
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    formData.set("vehicleId", vehicleId);
+    formData.set("projectId", projectId);
+    try {
+      const result = await addItemFn({ data: formData });
+      if (result && "error" in result) {
+        setError(result.error ?? "Failed to add item");
+      } else {
+        form.reset();
+        await router.invalidate();
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      {error ? <p className={errorBox}>{error}</p> : null}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-[2fr_1fr_4rem_auto]">
+        <label className={label}>
+          Part / item
+          <input
+            name="name"
+            required
+            placeholder="Hawk DTC-30 front pads"
+            className={input}
+          />
+        </label>
+        <label className={label}>
+          Price each
+          <input
+            name="price"
+            type="number"
+            step="0.01"
+            inputMode="decimal"
+            placeholder="189.00"
+            className={input}
+          />
+        </label>
+        <label className={label}>
+          Qty
+          <input
+            name="quantity"
+            type="number"
+            inputMode="numeric"
+            defaultValue={1}
+            min={1}
+            className={input}
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={pending}
+          className={`${btnSecondary} self-end`}
+        >
+          Add
+        </button>
+      </div>
+      <label className={label}>
+        Link (store page, forum thread…)
+        <input
+          name="url"
+          type="url"
+          placeholder="https://…"
+          className={input}
+        />
+      </label>
+    </form>
+  );
+}
+
+function ProjectDetail() {
+  const router = useRouter();
+  const navigate = useNavigate();
+  const { vehicleId, projectId } = useParams({
+    from: "/_authed/vehicles/$vehicleId/projects/$projectId",
+  });
+  const project = Route.useLoaderData();
+
+  const estimated = project.items.reduce(
+    (sum, i) => sum + (i.price ?? 0) * i.quantity,
+    0,
+  );
+  const committed = project.items
+    .filter((i) => i.status !== "proposed")
+    .reduce((sum, i) => sum + (i.price ?? 0) * i.quantity, 0);
+  const installedCount = project.items.filter(
+    (i) => i.status === "installed",
+  ).length;
+
+  async function onDelete() {
+    if (!window.confirm(`Delete project "${project.title}" and its items?`))
+      return;
+    await deleteProjectFn({ data: { vehicleId, projectId } });
+    await router.invalidate();
+    navigate({ to: "/vehicles/$vehicleId/projects", params: { vehicleId } });
+  }
+
+  return (
+    <section className="space-y-5">
+      <div>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-xl font-bold text-ink">{project.title}</h2>
+          <select
+            value={project.status}
+            aria-label="Project status"
+            className="min-h-11 rounded-xl border border-line bg-card px-3 text-sm font-semibold text-ink"
+            onChange={async (e) => {
+              await setProjectStatusFn({
+                data: {
+                  vehicleId,
+                  projectId,
+                  status: e.target.value as ProjectStatus,
+                },
+              });
+              await router.invalidate();
+            }}
+          >
+            {PROJECT_STATUSES.map((s) => (
+              <option key={s} value={s}>
+                {PROJECT_STATUS_LABELS[s]}
+              </option>
+            ))}
+          </select>
+        </div>
+        {project.description ? (
+          <p className="mt-2 whitespace-pre-wrap text-sm text-ink-muted">
+            {project.description}
+          </p>
+        ) : null}
+        <div className="mt-3 flex flex-wrap gap-2 text-xs font-semibold">
+          {project.targetDate ? (
+            <span
+              className={`rounded-full px-2.5 py-1 ${
+                daysUntil(project.targetDate) < 0
+                  ? "bg-danger/15 text-danger"
+                  : daysUntil(project.targetDate) <= 14
+                    ? "bg-warn/15 text-warn"
+                    : "bg-sunken text-ink-muted"
+              }`}
+            >
+              🏁{" "}
+              {daysUntil(project.targetDate) >= 0
+                ? `${daysUntil(project.targetDate)} days to ${project.targetDate.toLocaleDateString()}`
+                : `target was ${project.targetDate.toLocaleDateString()}`}
+            </span>
+          ) : null}
+          <span className="rounded-full bg-sunken px-2.5 py-1 text-ink-muted">
+            ~${Math.round(estimated).toLocaleString()} estimated
+          </span>
+          <span className="rounded-full bg-sunken px-2.5 py-1 text-ink-muted">
+            ${Math.round(committed).toLocaleString()} committed
+          </span>
+          <span className="rounded-full bg-sunken px-2.5 py-1 text-ink-muted">
+            {installedCount}/{project.items.length} installed
+          </span>
+        </div>
+      </div>
+
+      <div className={`${card} p-5`}>
+        <h3 className="font-bold text-ink">Parts & items</h3>
+        {project.items.length === 0 ? (
+          <p className="mt-2 text-sm text-ink-muted">
+            No items yet — add parts below as you spec the build.
+          </p>
+        ) : (
+          <ul className="mt-3 divide-y divide-line">
+            {project.items.map((item) => (
+              <li
+                key={item.id}
+                className="flex flex-wrap items-center gap-3 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium text-ink">
+                    {item.url ? (
+                      <a
+                        href={item.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="underline decoration-line underline-offset-2 hover:decoration-accent"
+                      >
+                        {item.name}
+                      </a>
+                    ) : (
+                      item.name
+                    )}
+                    {item.quantity > 1 ? ` ×${item.quantity}` : ""}
+                  </p>
+                  <p className="text-xs text-ink-muted">
+                    {item.price != null
+                      ? `$${(item.price * item.quantity).toLocaleString(undefined, { maximumFractionDigits: 2 })}`
+                      : "no price yet"}
+                  </p>
+                </div>
+                <select
+                  value={item.status}
+                  aria-label={`${item.name} status`}
+                  className="min-h-11 rounded-xl border border-line bg-card px-2 text-sm font-semibold text-ink"
+                  onChange={async (e) => {
+                    await setItemStatusFn({
+                      data: {
+                        vehicleId,
+                        projectId,
+                        itemId: item.id,
+                        status: e.target.value as ItemStatus,
+                      },
+                    });
+                    await router.invalidate();
+                  }}
+                >
+                  {ITEM_STATUSES.map((s) => (
+                    <option key={s} value={s}>
+                      {ITEM_STATUS_LABELS[s]}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  aria-label={`Delete ${item.name}`}
+                  className="min-h-11 px-2 text-sm text-danger hover:underline"
+                  onClick={async () => {
+                    await deleteItemFn({
+                      data: { vehicleId, projectId, itemId: item.id },
+                    });
+                    await router.invalidate();
+                  }}
+                >
+                  ✕
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="mt-4 border-t border-line pt-4">
+          <AddItemForm vehicleId={vehicleId} projectId={projectId} />
+        </div>
+      </div>
+
+      <div className="text-right">
+        <button
+          type="button"
+          onClick={onDelete}
+          className="text-sm text-danger hover:underline"
+        >
+          Delete project
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/app/routes/_authed.vehicles.$vehicleId.projects.index.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.projects.index.tsx
@@ -1,0 +1,214 @@
+import {
+  createFileRoute,
+  Link,
+  useParams,
+  useRouter,
+} from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { useState } from "react";
+
+import { requireAuth } from "~/auth/session.server";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  errorBox,
+  input,
+  label,
+  textarea,
+} from "~/components/ui";
+import { createProject, listProjects } from "~/models/project.server";
+
+const listProjectsFn = createServerFn({ method: "GET" })
+  .inputValidator((vehicleId: string) => vehicleId)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    return listProjects({ vehicleId: data, userId });
+  });
+
+const createProjectFn = createServerFn({ method: "POST" })
+  .inputValidator((data: FormData) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    const vehicleId = String(data.get("vehicleId") ?? "");
+    const title = String(data.get("title") ?? "").trim();
+    if (!title || !vehicleId) return { error: "Title is required" as const };
+    const targetDateRaw = String(data.get("targetDate") ?? "").trim();
+    const project = await createProject({
+      vehicleId,
+      userId,
+      title,
+      description: String(data.get("description") ?? "").trim() || null,
+      targetDate: targetDateRaw ? new Date(targetDateRaw) : null,
+      status: "idea",
+    });
+    return { projectId: project.id };
+  });
+
+export const Route = createFileRoute("/_authed/vehicles/$vehicleId/projects/")({
+  component: ProjectsList,
+  loader: async ({ params }) =>
+    (await listProjectsFn({ data: params.vehicleId })) ?? [],
+});
+
+const STATUS_LABELS: Record<string, string> = {
+  idea: "💡 idea",
+  planned: "📋 planned",
+  in_progress: "🔧 in progress",
+  done: "✅ done",
+};
+
+function daysUntil(date: Date): number {
+  return Math.ceil((date.getTime() - Date.now()) / (24 * 60 * 60 * 1000));
+}
+
+function NewProjectForm({ vehicleId }: { vehicleId: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setPending(true);
+    const formData = new FormData(e.currentTarget);
+    formData.set("vehicleId", vehicleId);
+    try {
+      const result = await createProjectFn({ data: formData });
+      if (result && "error" in result) {
+        setError(result.error ?? "Failed to create project");
+      } else {
+        setOpen(false);
+        await router.invalidate();
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={btnPrimary}
+      >
+        + New project
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className={`${card} space-y-4 p-5`}>
+      {error ? <p className={errorBox}>{error}</p> : null}
+      <label className={label}>
+        Project name
+        <input
+          name="title"
+          required
+          placeholder="Rally prep — Gorman Ridge"
+          className={input}
+        />
+      </label>
+      <label className={label}>
+        What's the plan?
+        <textarea
+          name="description"
+          rows={3}
+          placeholder="Full service + skid plate + spare wheel setup before the event"
+          className={textarea}
+        />
+      </label>
+      <label className={label}>
+        Target date (event day, deadline…)
+        <input name="targetDate" type="date" className={input} />
+      </label>
+      <div className="flex gap-2">
+        <button type="submit" disabled={pending} className={btnPrimary}>
+          {pending ? "Creating…" : "Create project"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className={btnSecondary}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function ProjectsList() {
+  const { vehicleId } = useParams({
+    from: "/_authed/vehicles/$vehicleId/projects/",
+  });
+  const projects = Route.useLoaderData();
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-bold text-ink">Builds & plans</h2>
+      <NewProjectForm vehicleId={vehicleId} />
+      {projects.length === 0 ? (
+        <p className="text-sm text-ink-muted">
+          Nothing planned yet. Projects collect parts, prices, and progress for
+          bigger jobs — a rally build, a suspension refresh, that turbo you keep
+          talking about.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {projects.map((p) => (
+            <li key={p.id}>
+              <Link
+                to="/vehicles/$vehicleId/projects/$projectId"
+                params={{ vehicleId, projectId: p.id }}
+                className={`${card} block p-5 transition-shadow hover:shadow-md`}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-bold text-ink">{p.title}</span>
+                  <span className="text-xs font-semibold text-ink-muted">
+                    {STATUS_LABELS[p.status] ?? p.status}
+                  </span>
+                </div>
+                {p.description ? (
+                  <p className="mt-1 line-clamp-2 text-sm text-ink-muted">
+                    {p.description}
+                  </p>
+                ) : null}
+                <div className="mt-3 flex flex-wrap gap-2 text-xs font-semibold">
+                  {p.targetDate ? (
+                    <span
+                      className={`rounded-full px-2.5 py-1 ${
+                        daysUntil(p.targetDate) < 0
+                          ? "bg-danger/15 text-danger"
+                          : daysUntil(p.targetDate) <= 14
+                            ? "bg-warn/15 text-warn"
+                            : "bg-sunken text-ink-muted"
+                      }`}
+                    >
+                      {daysUntil(p.targetDate) >= 0
+                        ? `${daysUntil(p.targetDate)} days out`
+                        : `${-daysUntil(p.targetDate)} days past target`}
+                    </span>
+                  ) : null}
+                  <span className="rounded-full bg-sunken px-2.5 py-1 text-ink-muted">
+                    {p.itemCount} {p.itemCount === 1 ? "item" : "items"}
+                  </span>
+                  {p.estimatedTotal > 0 ? (
+                    <span className="rounded-full bg-sunken px-2.5 py-1 text-ink-muted">
+                      ~${Math.round(p.estimatedTotal).toLocaleString()} est
+                      {p.committedTotal > 0
+                        ? ` · $${Math.round(p.committedTotal).toLocaleString()} committed`
+                        : ""}
+                    </span>
+                  ) : null}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/app/routes/_authed.vehicles.$vehicleId.reminders.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.reminders.tsx
@@ -1,0 +1,316 @@
+import {
+  createFileRoute,
+  Link,
+  useParams,
+  useRouter,
+} from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { useState } from "react";
+
+import { requireAuth } from "~/auth/session.server";
+import { statusBadgeClass, statusLabel } from "~/components/reminder-display";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  errorBox,
+  input,
+  label,
+} from "~/components/ui";
+import {
+  completeReminder,
+  createReminder,
+  deleteReminder,
+  listReminders,
+} from "~/models/reminder.server";
+
+const listRemindersFn = createServerFn({ method: "GET" })
+  .inputValidator((vehicleId: string) => vehicleId)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    return listReminders({ vehicleId: data, userId });
+  });
+
+const createReminderFn = createServerFn({ method: "POST" })
+  .inputValidator((data: FormData) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    const vehicleId = String(data.get("vehicleId") ?? "");
+    const title = String(data.get("title") ?? "").trim();
+    if (!title || !vehicleId) return { error: "Title is required" as const };
+
+    const num = (name: string) => {
+      const raw = String(data.get(name) ?? "").trim();
+      return raw ? Number.parseFloat(raw) : null;
+    };
+    const dueDateRaw = String(data.get("dueDate") ?? "").trim();
+
+    await createReminder({
+      vehicleId,
+      userId,
+      title,
+      notes: String(data.get("notes") ?? "").trim() || null,
+      dueDate: dueDateRaw ? new Date(dueDateRaw) : null,
+      dueMiles: num("dueMiles"),
+      intervalMonths: num("intervalMonths"),
+      intervalMiles: num("intervalMiles"),
+    });
+    return { ok: true as const };
+  });
+
+const completeReminderFn = createServerFn({ method: "POST" })
+  .inputValidator((data: { vehicleId: string; reminderId: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await completeReminder({
+      id: data.reminderId,
+      vehicleId: data.vehicleId,
+      userId,
+    });
+  });
+
+const deleteReminderFn = createServerFn({ method: "POST" })
+  .inputValidator((data: { vehicleId: string; reminderId: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await deleteReminder({
+      id: data.reminderId,
+      vehicleId: data.vehicleId,
+      userId,
+    });
+  });
+
+export const Route = createFileRoute("/_authed/vehicles/$vehicleId/reminders")({
+  component: Reminders,
+  loader: async ({ params }) =>
+    (await listRemindersFn({ data: params.vehicleId })) ?? [],
+});
+
+function NewReminderForm({ vehicleId }: { vehicleId: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setPending(true);
+    const formData = new FormData(e.currentTarget);
+    formData.set("vehicleId", vehicleId);
+    try {
+      const result = await createReminderFn({ data: formData });
+      if (result && "error" in result) {
+        setError(result.error ?? "Failed to save reminder");
+      } else {
+        setOpen(false);
+        await router.invalidate();
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={btnPrimary}
+      >
+        + Add reminder
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className={`${card} space-y-4 p-5`}>
+      {error ? <p className={errorBox}>{error}</p> : null}
+      <label className={label}>
+        What needs doing?
+        <input
+          name="title"
+          required
+          placeholder="Oil change"
+          className={input}
+        />
+      </label>
+      <div className="grid grid-cols-2 gap-3">
+        <label className={label}>
+          Due date
+          <input name="dueDate" type="date" className={input} />
+        </label>
+        <label className={label}>
+          Due at miles
+          <input
+            name="dueMiles"
+            type="number"
+            inputMode="numeric"
+            placeholder="98500"
+            className={input}
+          />
+        </label>
+      </div>
+      <fieldset>
+        <legend className="text-sm font-medium text-ink-muted">
+          Repeats? (leave blank for one-time)
+        </legend>
+        <div className="mt-1 grid grid-cols-2 gap-3">
+          <label className={label}>
+            Every X months
+            <input
+              name="intervalMonths"
+              type="number"
+              inputMode="numeric"
+              placeholder="6"
+              className={input}
+            />
+          </label>
+          <label className={label}>
+            Every X miles
+            <input
+              name="intervalMiles"
+              type="number"
+              inputMode="numeric"
+              placeholder="5000"
+              className={input}
+            />
+          </label>
+        </div>
+      </fieldset>
+      <label className={label}>
+        Notes
+        <input
+          name="notes"
+          placeholder="5W-30 synthetic, OEM filter"
+          className={input}
+        />
+      </label>
+      <div className="flex gap-2">
+        <button type="submit" disabled={pending} className={btnPrimary}>
+          {pending ? "Saving…" : "Save reminder"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className={btnSecondary}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function Reminders() {
+  const router = useRouter();
+  const { vehicleId } = useParams({
+    from: "/_authed/vehicles/$vehicleId/reminders",
+  });
+  const reminders = Route.useLoaderData();
+  const active = reminders.filter((r) => r.status !== "done");
+  const done = reminders.filter((r) => r.status === "done");
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-xl font-bold text-ink">Service reminders</h2>
+      </div>
+      <NewReminderForm vehicleId={vehicleId} />
+      {active.length === 0 ? (
+        <p className="text-sm text-ink-muted">
+          No upcoming reminders. Anything with a date or mileage target goes
+          here — oil, brakes, tires, rally tech inspection…
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {active.map((r) => (
+            <li key={r.id} className={`${card} p-4`}>
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="min-w-0 flex-1">
+                  <p className="font-semibold text-ink">{r.title}</p>
+                  {r.notes ? (
+                    <p className="mt-0.5 text-sm text-ink-muted">{r.notes}</p>
+                  ) : null}
+                  <p className="mt-1 text-xs text-ink-muted">
+                    {r.intervalMiles != null || r.intervalMonths != null
+                      ? `repeats${r.intervalMonths != null ? ` every ${r.intervalMonths} mo` : ""}${r.intervalMiles != null ? ` every ${Math.round(r.intervalMiles).toLocaleString()} mi` : ""}`
+                      : "one-time"}
+                  </p>
+                </div>
+                <span className={statusBadgeClass(r.status)}>
+                  {statusLabel(r)}
+                </span>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Link
+                  to="/vehicles/$vehicleId/logs/new"
+                  params={{ vehicleId }}
+                  search={{ reminder: r.id }}
+                  className={btnPrimary}
+                >
+                  Did it — log the work
+                </Link>
+                <button
+                  type="button"
+                  className={btnSecondary}
+                  onClick={async () => {
+                    await completeReminderFn({
+                      data: { vehicleId, reminderId: r.id },
+                    });
+                    await router.invalidate();
+                  }}
+                >
+                  Mark done
+                </button>
+                <button
+                  type="button"
+                  className="min-h-11 px-3 text-sm text-danger hover:underline"
+                  onClick={async () => {
+                    if (!window.confirm(`Delete reminder "${r.title}"?`))
+                      return;
+                    await deleteReminderFn({
+                      data: { vehicleId, reminderId: r.id },
+                    });
+                    await router.invalidate();
+                  }}
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      {done.length > 0 ? (
+        <details>
+          <summary className="cursor-pointer text-sm font-semibold text-ink-muted">
+            Completed ({done.length})
+          </summary>
+          <ul className="mt-3 space-y-2">
+            {done.map((r) => (
+              <li
+                key={r.id}
+                className="flex items-center justify-between gap-3 text-sm text-ink-muted"
+              >
+                <span className="line-through">{r.title}</span>
+                <button
+                  type="button"
+                  className="text-danger hover:underline"
+                  onClick={async () => {
+                    await deleteReminderFn({
+                      data: { vehicleId, reminderId: r.id },
+                    });
+                    await router.invalidate();
+                  }}
+                >
+                  Delete
+                </button>
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </section>
+  );
+}

--- a/app/routes/_authed.vehicles.$vehicleId.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.tsx
@@ -1,4 +1,9 @@
-import { createFileRoute, notFound, Outlet } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  Link,
+  notFound,
+  Outlet,
+} from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 
 import { requireAuth } from "~/auth/session.server";
@@ -20,6 +25,66 @@ export const Route = createFileRoute("/_authed/vehicles/$vehicleId")({
   },
 });
 
+const tabs = [
+  { to: "/vehicles/$vehicleId", label: "Dashboard", exact: true },
+  { to: "/vehicles/$vehicleId/logs", label: "Logs", exact: false },
+  { to: "/vehicles/$vehicleId/reminders", label: "Reminders", exact: false },
+  { to: "/vehicles/$vehicleId/projects", label: "Projects", exact: false },
+] as const;
+
 function VehicleLayout() {
-  return <Outlet />;
+  const v = Route.useLoaderData();
+
+  return (
+    <div>
+      <div className="flex items-center gap-4">
+        {v.avatarPath ? (
+          <img
+            src={`/files/${v.avatarPath}`}
+            alt=""
+            className="h-14 w-14 rounded-2xl object-cover"
+          />
+        ) : (
+          <span
+            aria-hidden
+            className="flex h-14 w-14 items-center justify-center rounded-2xl bg-sunken text-2xl"
+          >
+            🚗
+          </span>
+        )}
+        <div className="min-w-0">
+          <h1 className="truncate text-xl font-bold text-ink sm:text-2xl">
+            {v.name ?? `${v.year} ${v.make} ${v.model}`}
+          </h1>
+          <p className="truncate text-sm text-ink-muted">
+            {v.name ? `${v.year} ${v.make} ${v.model}` : null}
+            {v.name && v.trim ? ` ${v.trim}` : !v.name && v.trim ? v.trim : ""}
+            {v.role === "member" ? " · shared with you" : ""}
+          </p>
+        </div>
+      </div>
+      <nav className="-mx-4 mt-4 flex gap-1 overflow-x-auto border-b border-line px-4 sm:mx-0 sm:px-0">
+        {tabs.map((tab) => (
+          <Link
+            key={tab.to}
+            to={tab.to}
+            params={{ vehicleId: v.id }}
+            activeOptions={{ exact: tab.exact }}
+            activeProps={{
+              className: "border-accent text-ink",
+            }}
+            inactiveProps={{
+              className: "border-transparent text-ink-muted hover:text-ink",
+            }}
+            className="whitespace-nowrap border-b-2 px-3 py-3 text-sm font-semibold"
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+      <div className="mt-6">
+        <Outlet />
+      </div>
+    </div>
+  );
 }

--- a/app/routes/_authed.vehicles.index.tsx
+++ b/app/routes/_authed.vehicles.index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 
 import { requireAuth } from "~/auth/session.server";
+import { btnPrimary, card } from "~/components/ui";
 import { getVehicleListItems } from "~/models/vehicle.server";
 
 const listVehiclesFn = createServerFn({ method: "GET" }).handler(async () => {
@@ -18,38 +19,85 @@ function VehicleList() {
   const vehicles = Route.useLoaderData();
   return (
     <section>
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-slate-900">Your vehicles</h1>
-        <Link
-          to="/vehicles/new"
-          className="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
-        >
-          Add vehicle
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="text-2xl font-bold text-ink">The garage</h1>
+        <Link to="/vehicles/new" className={btnPrimary}>
+          + Add vehicle
         </Link>
       </div>
       {vehicles.length === 0 ? (
-        <p className="mt-8 text-slate-600">
-          No vehicles yet. Add one to start logging maintenance.
-        </p>
+        <div className={`${card} mt-8 p-8 text-center`}>
+          <p className="text-4xl" aria-hidden>
+            🏎️
+          </p>
+          <p className="mt-3 font-semibold text-ink">The garage is empty</p>
+          <p className="mt-1 text-sm text-ink-muted">
+            Add a vehicle to start logging work, setting service reminders, and
+            planning builds.
+          </p>
+        </div>
       ) : (
-        <ul className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <ul className="mt-6 grid gap-4 sm:grid-cols-2">
           {vehicles.map((v) => (
-            <li
-              key={v.id}
-              className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
-            >
+            <li key={v.id}>
               <Link
                 to="/vehicles/$vehicleId"
                 params={{ vehicleId: v.id }}
-                className="block"
+                className={`${card} block p-5 transition-shadow hover:shadow-md`}
               >
-                <div className="text-lg font-medium text-slate-900">
-                  {v.year} {v.make} {v.model}
-                  {v.trim ? ` ${v.trim}` : ""}
+                <div className="flex items-start gap-4">
+                  {v.avatarPath ? (
+                    <img
+                      src={`/files/${v.avatarPath}`}
+                      alt=""
+                      className="h-16 w-16 rounded-xl object-cover"
+                    />
+                  ) : (
+                    <span
+                      aria-hidden
+                      className="flex h-16 w-16 items-center justify-center rounded-xl bg-sunken text-3xl"
+                    >
+                      🚗
+                    </span>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-lg font-bold text-ink">
+                      {v.name ?? `${v.year} ${v.make} ${v.model}`}
+                    </div>
+                    <div className="truncate text-sm text-ink-muted">
+                      {v.name
+                        ? `${v.year} ${v.make} ${v.model}${v.trim ? ` ${v.trim}` : ""}`
+                        : (v.trim ?? "")}
+                    </div>
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-xs font-semibold">
+                      {v.latestOdometer != null ? (
+                        <span className="rounded-full bg-sunken px-2.5 py-1 text-ink-muted">
+                          {Math.round(v.latestOdometer).toLocaleString()} mi
+                        </span>
+                      ) : null}
+                      {v.overdueCount > 0 ? (
+                        <span className="rounded-full bg-danger/15 px-2.5 py-1 text-danger">
+                          {v.overdueCount} overdue
+                        </span>
+                      ) : null}
+                      {v.dueSoonCount > 0 ? (
+                        <span className="rounded-full bg-warn/15 px-2.5 py-1 text-warn">
+                          {v.dueSoonCount} due soon
+                        </span>
+                      ) : null}
+                      {v.overdueCount === 0 && v.dueSoonCount === 0 ? (
+                        <span className="rounded-full bg-ok/15 px-2.5 py-1 text-ok">
+                          all good
+                        </span>
+                      ) : null}
+                      {v.role === "member" ? (
+                        <span className="rounded-full bg-sunken px-2.5 py-1 text-ink-muted">
+                          shared
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
                 </div>
-                {v.name ? (
-                  <div className="text-sm text-slate-500">“{v.name}”</div>
-                ) : null}
               </Link>
             </li>
           ))}

--- a/app/routes/_authed.vehicles.new.tsx
+++ b/app/routes/_authed.vehicles.new.tsx
@@ -4,6 +4,12 @@ import { createServerFn } from "@tanstack/react-start";
 import { useState } from "react";
 
 import { requireAuth } from "~/auth/session.server";
+import {
+  btnPrimary,
+  errorBox,
+  input,
+  label as labelClass,
+} from "~/components/ui";
 import { createVehicle } from "~/models/vehicle.server";
 import { getStorage } from "~/storage.server";
 
@@ -87,32 +93,24 @@ function NewVehiclePage() {
 
   return (
     <section>
-      <h1 className="text-2xl font-semibold text-slate-900">Add vehicle</h1>
+      <h1 className="text-2xl font-bold text-ink">Add vehicle</h1>
       <form onSubmit={onSubmit} className="mt-6 max-w-lg space-y-4">
-        {error ? (
-          <p className="rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
-            {error}
-          </p>
-        ) : null}
+        {error ? <p className={errorBox}>{error}</p> : null}
         <Field name="name" label="Name (optional)" />
         <Field name="make" label="Make" required />
         <Field name="model" label="Model" required />
         <Field name="trim" label="Trim (optional)" />
         <Field name="year" label="Year" type="number" required />
-        <label className="block text-sm font-medium text-slate-700">
-          Avatar (PNG or JPEG, ≤500KB, optional)
+        <label className={labelClass}>
+          Photo (PNG or JPEG, ≤500KB, optional)
           <input
             name="avatar"
             type="file"
             accept="image/png,image/jpeg"
-            className="mt-1 block w-full text-sm"
+            className="mt-1 block w-full text-sm text-ink"
           />
         </label>
-        <button
-          type="submit"
-          disabled={pending}
-          className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
-        >
+        <button type="submit" disabled={pending} className={btnPrimary}>
           {pending ? "Saving…" : "Save"}
         </button>
       </form>
@@ -132,14 +130,9 @@ function Field({
   required?: boolean;
 }) {
   return (
-    <label className="block text-sm font-medium text-slate-700">
+    <label className={labelClass}>
       {label}
-      <input
-        name={name}
-        type={type}
-        required={required}
-        className="mt-1 w-full rounded border border-slate-300 p-2"
-      />
+      <input name={name} type={type} required={required} className={input} />
     </label>
   );
 }

--- a/app/routes/account.export.tsx
+++ b/app/routes/account.export.tsx
@@ -100,7 +100,7 @@ export const Route = createFileRoute("/account/export")({
 
         return Response.json(body, {
           headers: {
-            "content-disposition": `attachment; filename="vehicle-work-log-${user.email}.json"`,
+            "content-disposition": `attachment; filename="crew-chief-${user.email}.json"`,
           },
         });
       },

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -8,9 +8,7 @@ function Home() {
   return (
     <main className="flex min-h-screen items-center justify-center bg-slate-50 p-8">
       <div className="w-full max-w-xl rounded-2xl bg-white p-8 shadow-sm">
-        <h1 className="text-3xl font-semibold text-slate-900">
-          Vehicle Work Log
-        </h1>
+        <h1 className="text-3xl font-semibold text-slate-900">Crew Chief</h1>
         <p className="mt-2 text-slate-600">
           Keep a maintenance record for every car you own.
         </p>

--- a/app/styles.css
+++ b/app/styles.css
@@ -1,1 +1,63 @@
 @import "tailwindcss";
+
+/*
+ * Semantic color tokens. Utilities like `bg-surface` / `text-ink` resolve
+ * these CSS variables at runtime (via @theme inline), so toggling the
+ * `.garage` class on <html> reskins the whole app without a rebuild.
+ *
+ * Garage Mode = high-contrast dark palette + larger base font, tuned for
+ * reading at arm's length under bad shop lighting with greasy thumbs.
+ */
+:root {
+  --app-surface: #f4f5f7;
+  --app-card: #ffffff;
+  --app-sunken: #eceef2;
+  --app-ink: #0f172a;
+  --app-ink-muted: #64748b;
+  --app-line: #e2e8f0;
+  --app-accent: #c2410c; /* safety orange, dark enough for white text */
+  --app-accent-strong: #9a3412;
+  --app-accent-ink: #ffffff;
+  --app-ok: #15803d;
+  --app-warn: #b45309;
+  --app-danger: #dc2626;
+}
+
+.garage {
+  --app-surface: #0c0e11;
+  --app-card: #171a20;
+  --app-sunken: #101216;
+  --app-ink: #f5f6f7;
+  --app-ink-muted: #a3adb8;
+  --app-line: #2b313a;
+  --app-accent: #fb923c; /* brighter orange pops on dark */
+  --app-accent-strong: #f97316;
+  --app-accent-ink: #1c1004; /* near-black text on bright orange */
+  --app-ok: #4ade80;
+  --app-warn: #fbbf24;
+  --app-danger: #f87171;
+}
+
+@theme inline {
+  --color-surface: var(--app-surface);
+  --color-card: var(--app-card);
+  --color-sunken: var(--app-sunken);
+  --color-ink: var(--app-ink);
+  --color-ink-muted: var(--app-ink-muted);
+  --color-line: var(--app-line);
+  --color-accent: var(--app-accent);
+  --color-accent-strong: var(--app-accent-strong);
+  --color-accent-ink: var(--app-accent-ink);
+  --color-ok: var(--app-ok);
+  --color-warn: var(--app-warn);
+  --color-danger: var(--app-danger);
+}
+
+html {
+  background-color: var(--app-surface);
+}
+
+/* Bigger type everywhere in the shop — Tailwind sizes are rem-based. */
+html.garage {
+  font-size: 18px;
+}

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "files": {
     "includes": [
       "**",
@@ -11,8 +11,15 @@
       "!**/build",
       "!**/public/build",
       "!**/app/routeTree.gen.ts",
-      "!**/app/db/migrations"
+      "!**/app/db/migrations",
+      "!**/test-results",
+      "!**/playwright-report"
     ]
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
   },
   "formatter": {
     "enabled": true,

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -8,10 +8,20 @@ function generateTestEmail() {
 }
 
 const TEST_PASSWORD = "myreallystrongpassword";
-const ERROR_SELECTOR = '[class*="red"]';
+// Error banners are <p> with a bg-danger token (or legacy red on auth pages).
+const ERROR_SELECTOR = 'p[class*="bg-danger"], [class*="bg-red"]';
 
 async function expectNoErrors(page: Page) {
   await expect(page.locator(ERROR_SELECTOR)).not.toBeVisible();
+}
+
+/**
+ * Auth forms submit via JS (createServerFn), so a click before hydration
+ * falls back to a native GET submit and loses the input. Wait for the
+ * network to go idle (dev-server bundles included) before interacting.
+ */
+async function waitForHydration(page: Page) {
+  await page.waitForLoadState("networkidle");
 }
 
 test.describe("smoke tests", () => {
@@ -29,14 +39,19 @@ test.describe("smoke tests", () => {
     await page.goto("/");
     await page.getByRole("link", { name: /sign up/i }).click();
 
+    await waitForHydration(page);
     await page.getByLabel(/email/i).fill(testEmail);
     await page.getByLabel(/password/i).fill(TEST_PASSWORD);
     await page.getByRole("button", { name: /create account/i }).click();
 
     await page.waitForURL("**/vehicles**");
-    await expect(page.getByText(/your vehicles/i)).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /the garage/i }),
+    ).toBeVisible();
     await expectNoErrors(page);
 
+    await waitForHydration(page);
+    await page.getByRole("button", { name: /^[A-Z]$/ }).click();
     await page.getByRole("link", { name: /log out/i }).click();
     await page.waitForURL("**/");
     await expect(
@@ -51,12 +66,15 @@ test.describe("smoke tests", () => {
 
     // Register a new account
     await page.goto("/join");
+    await waitForHydration(page);
     await page.getByLabel(/email/i).fill(testEmail);
     await page.getByLabel(/password/i).fill(TEST_PASSWORD);
     await page.getByRole("button", { name: /create account/i }).click();
     await page.waitForURL("**/vehicles**");
 
-    // Log out
+    // Log out (via the avatar menu)
+    await waitForHydration(page);
+    await page.getByRole("button", { name: /^[A-Z]$/ }).click();
     await page.getByRole("link", { name: /log out/i }).click();
     await page.waitForURL("**/");
 
@@ -67,7 +85,9 @@ test.describe("smoke tests", () => {
     await page.getByRole("button", { name: /sign in/i }).click();
 
     await page.waitForURL("**/vehicles**");
-    await expect(page.getByText(/your vehicles/i)).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /the garage/i }),
+    ).toBeVisible();
     await expectNoErrors(page);
   });
 
@@ -83,6 +103,7 @@ test.describe("smoke tests", () => {
 
     // Register via UI
     await page.goto("/join");
+    await waitForHydration(page);
     await page.getByLabel(/email/i).fill(testEmail);
     await page.getByLabel(/password/i).fill(TEST_PASSWORD);
     await page.getByRole("button", { name: /create account/i }).click();
@@ -90,7 +111,7 @@ test.describe("smoke tests", () => {
     await expectNoErrors(page);
 
     // Empty state
-    await expect(page.getByText(/no vehicles yet/i)).toBeVisible();
+    await expect(page.getByText(/the garage is empty/i)).toBeVisible();
 
     // Create vehicle
     await page.getByRole("link", { name: /add vehicle/i }).click();
@@ -99,30 +120,33 @@ test.describe("smoke tests", () => {
     await page.getByLabel(/year/i).fill(vehicleYear);
     await page.getByRole("button", { name: /save/i }).click();
 
-    // Verify redirect to vehicle detail (no error flash)
+    // Verify redirect to the vehicle dashboard (no error flash)
     await page.waitForURL("**/vehicles/**");
     await expectNoErrors(page);
-    await page.getByRole("link", { name: /view service logs/i }).click();
+    await page.getByRole("link", { name: /^logs$/i }).click();
 
     // Logs empty state
-    await expect(page.getByText(/no logs yet/i)).toBeVisible();
+    await expect(page.getByText(/nothing logged yet/i)).toBeVisible();
 
-    // Create log
-    await page.getByRole("link", { name: /add log/i }).click();
+    // Create log via quick capture
+    await page.getByRole("link", { name: /log work/i }).click();
     await page.getByLabel(/title/i).fill(logTitle);
     await page.getByLabel(/notes/i).fill(logNotes);
-    await page.getByRole("button", { name: /save log/i }).click();
+    await page.getByRole("button", { name: /save it/i }).click();
 
-    // Verify log detail (no error flash)
+    // Saving lands on the dashboard with the log in "Recent work"
     await expect(page.getByText(logTitle)).toBeVisible();
-    await expect(page.getByText(logNotes)).toBeVisible();
     await expectNoErrors(page);
+
+    // Open the log detail and verify notes
+    await page.getByRole("link", { name: logTitle }).click();
+    await expect(page.getByText(logNotes)).toBeVisible();
 
     // Delete log (confirm dialog fires on click)
     page.on("dialog", (dialog) => dialog.accept());
     await page.getByRole("button", { name: /delete/i }).click();
 
     // Verify empty state again
-    await expect(page.getByText(/no logs yet/i)).toBeVisible();
+    await expect(page.getByText(/nothing logged yet/i)).toBeVisible();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "vehicle-work-log",
+  "name": "crew-chief",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vehicle-work-log",
+      "name": "crew-chief",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.0.0",
         "@tanstack/react-router": "1.168.23",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vehicle-work-log",
+  "name": "crew-chief",
   "private": true,
   "type": "module",
   "engines": {
@@ -24,7 +24,7 @@
     "db:studio": "drizzle-kit studio",
     "db:seed": "node --env-file=.env --import tsx app/db/seed.ts",
     "docker:dev": "docker compose up -d",
-    "docker:build": "docker build -t vehicle-work-log:local .",
+    "docker:build": "docker build -t crew-chief:local .",
     "validate": "npm run typecheck && npm run lint && npm run test -- --run"
   },
   "dependencies": {


### PR DESCRIPTION
## What this does

Turns the utilitarian log into a shared garage companion:

- **Crew sharing** — `vehicle_members` table + email invites (instant add for existing users, pending invites claimed at signup). All vehicle-scoped data access now goes through `requireVehicleAccess` membership checks; the vehicle `userId` column remains the owner, who alone can delete the vehicle and manage the crew.
- **Service reminders** — due by date and/or mileage (whichever crosses first), urgency computed from the latest logged odometer. Recurring reminders roll forward from the completion odometer. "Did it — log the work" prefills the quick-log form and completes the reminder on save.
- **Projects** — builds with parts/prices through a proposed → ordered → received → installed pipeline, estimated vs committed totals, and target-date countdowns.
- **Vehicle dashboard** — odometer, next-up reminders, active builds, recent work, crew card, Log Work button. Garage list shows overdue/due-soon badges per vehicle.
- **Garage Mode** — runtime-flippable high-contrast dark theme (+18px base font) via semantic color tokens (`@theme inline` CSS vars); mobile-first restyle with ≥44px touch targets and tap-to-fill presets on the quick-log form.

## Schema

New migration `0002`: `vehicle_members`, `vehicle_invites`, `reminders`, `projects`, `project_items`, plus a backfill inserting owner memberships for existing vehicles.

## Testing

- `npm run validate` green: typecheck, Biome, 18 vitest integration tests (new crew/reminder/project suites incl. cross-user access denial)
- Playwright e2e smoke tests updated for the new UI — 3/3 passing locally
- Cloudflare production build compiles

## Notes

- Dev SSR env must come from `.dev.vars` (workerd can't see shell env) — documented in README + CLAUDE.md
- Biome: enabled `tailwindDirectives` CSS parsing for the new `@theme`/`@custom-variant` usage; excluded Playwright output dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)