### PR TITLE
docs: refresh CLAUDE.md and README after Crew Chief launch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,11 +166,36 @@ Remix/Prisma stack in places and are queued for a refresh pass.
   `.output/server/index.mjs` but runtime 404s on all routes — SSR
   fallback wiring. Tracked for the self-host image release.
 
-## Next up: Crew Chief MCP server
+## Next up (June 2026, in priority order)
 
-Planned (June 2026) so Scott's wife and her rally teammate can talk to
-Crew Chief from their own Claude accounts (claude.ai custom connector,
-works on mobile):
+### 1. Scan Bay — paper shop-record ingestion (local AI, $0)
+
+The app's core purpose is digitizing Scott's vehicle maintenance records,
+including a backlog of paper shop invoices. Plan validated against local
+hardware (M3 Pro / 18 GB, Ollama installed):
+
+- **Batch CLI** (`scripts/` + local Ollama `qwen3-vl:8b`, JSON-schema
+  structured output via `format` on `/api/chat`, temperature 0): folder of
+  scans → extracted JSON review file → import creates logs via the model
+  layer + stores the original scan with each log. Working extraction
+  prompt/schema prototype: `/tmp/extract-receipt.sh` (recreate if gone —
+  fields: shopName/location, invoiceNumber, serviceDate, vehicle, odometer,
+  totalCost, lineItems[], suggestedTitle, recommendedWork).
+- Needs a `log_attachments` table (logId, path, contentType) — storage
+  layer already handles uploads.
+- `recommendedWork` (tech notes like "pads at 5mm, replace in 5k mi") can
+  prefill a reminder.
+- **In-app one-off scans (phase 2):** same schema via Cloudflare Workers
+  AI binding (free tier) so phone captures work without the Mac.
+- Deliberately NOT the Anthropic API — cost. Don't suggest it for this.
+
+### 2. Crew Chief MCP server
+
+So the crew can talk to Crew Chief from their own Claude accounts
+(claude.ai custom connector, works on mobile). NOTE: rally-specific
+features stay OUT of the app — the app is generic vehicle maintenance;
+rally procedure lives in Scott's external rebelle-rally skill, which will
+call these MCP tools:
 
 - Remote MCP endpoint at `/mcp` on the existing Worker — Cloudflare
   `agents` SDK (`McpAgent`) + `workers-oauth-provider`, OAuth backed by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ user-facing context and tool-choice rationale.
 ```sh
 npm run docker:dev      # start local Postgres (pgvector/pgvector:pg16 on :5440)
 npm run db:migrate      # apply Drizzle migrations
-npm run db:seed         # creates scott@example.com / scottiscool + seed vehicle
+npm run db:seed         # scott@example.com / scottiscool + vehicle, log, reminders, project
 npm run db:generate     # after schema changes
 npm run db:studio       # Drizzle Studio against local DB
 npm run dev             # Vite dev server on :3000
@@ -165,6 +165,24 @@ Remix/Prisma stack in places and are queued for a refresh pass.
 - `npm run build:node` (Nitro + TanStack Start node preset) produces
   `.output/server/index.mjs` but runtime 404s on all routes — SSR
   fallback wiring. Tracked for the self-host image release.
+
+## Next up: Crew Chief MCP server
+
+Planned (June 2026) so Scott's wife and her rally teammate can talk to
+Crew Chief from their own Claude accounts (claude.ai custom connector,
+works on mobile):
+
+- Remote MCP endpoint at `/mcp` on the existing Worker — Cloudflare
+  `agents` SDK (`McpAgent`) + `workers-oauth-provider`, OAuth backed by
+  the existing `users` table + session auth (login screen on connect; no
+  API keys for end users).
+- Tools are thin wrappers over `app/models/*` so crew-membership
+  authorization is enforced for free: `log_work`, `whats_due`,
+  `complete_reminder`, `get_vehicle_status`, `list_projects`,
+  `add_project_item`, `update_item_status`.
+- A rally-prep skill (Rebelle Rally — Scott has a draft) layers event
+  procedure on top and calls these tools; keep event-specific content in
+  the skill, generic data access in MCP.
 
 ## Documentation policy
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ image.
 | Cloud deploy         | Cloudflare Workers + Hyperdrive + Neon + R2  |
 | Self-host deploy     | Single Docker image (app + Postgres + data volume) |
 | Lint / format        | [Biome 2](https://biomejs.dev)                |
-| Tests                | Vitest (integration), Playwright (planned)   |
+| Tests                | Vitest (integration), Playwright e2e smoke tests |
 | Auth                 | Cookie session via TanStack Start `useSession` + bcryptjs |
 | Styling              | Tailwind v4                                  |
 
@@ -331,8 +331,10 @@ breaking old bundles.
 
 Near-term:
 
-- Playwright e2e coverage for login → vehicle → avatar upload → log → export
-  flows
+- Extend Playwright e2e coverage to avatar upload, export, crew invites,
+  and reminder completion (registration/login/vehicle/log flows are covered)
+- MCP server on the Worker (`/mcp`) so the crew can log work and check
+  what's due from their own Claude accounts — OAuth against existing users
 - Finalize the single-container self-host image and publish the first GHCR
   release
 - Fix the Nitro 3 + TanStack Start node-build integration so `npm run build:node`


### PR DESCRIPTION
Post-launch freshness pass:

- CLAUDE.md: seed now includes reminders/project demo data; adds a "Next up: Crew Chief MCP server" section documenting the planned `/mcp` endpoint (Cloudflare `agents` McpAgent + `workers-oauth-provider`, tools wrapping `app/models/*` so crew-membership auth is enforced for free)
- README: Playwright is no longer "(planned)"; roadmap updated to reflect covered e2e flows and the MCP server plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)