### PR TITLE
feat: Scan Bay — local-AI batch ingestion of paper shop records

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@ SESSION_SECRET="change-me-to-something-random-at-least-32-chars-long"
 
 # Uploads directory (self-host only, ignored on Cloudflare)
 UPLOADS_DIR="./data/uploads"
+
+# Scan Bay — local receipt extraction (npm run scan:extract). Both optional;
+# defaults shown. Points the batch CLI at a local Ollama with a vision model.
+OLLAMA_HOST="http://localhost:11434"
+SCAN_MODEL="qwen3-vl:8b"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,11 +166,36 @@ Remix/Prisma stack in places and are queued for a refresh pass.
   `.output/server/index.mjs` but runtime 404s on all routes — SSR
   fallback wiring. Tracked for the self-host image release.
 
-## Next up: Crew Chief MCP server
+## Next up (June 2026, in priority order)
 
-Planned (June 2026) so Scott's wife and her rally teammate can talk to
-Crew Chief from their own Claude accounts (claude.ai custom connector,
-works on mobile):
+### 1. Scan Bay — paper shop-record ingestion (local AI, $0)
+
+The app's core purpose is digitizing Scott's vehicle maintenance records,
+including a backlog of paper shop invoices. Plan validated against local
+hardware (M3 Pro / 18 GB, Ollama installed):
+
+- **Batch CLI** (`scripts/` + local Ollama `qwen3-vl:8b`, JSON-schema
+  structured output via `format` on `/api/chat`, temperature 0): folder of
+  scans → extracted JSON review file → import creates logs via the model
+  layer + stores the original scan with each log. Working extraction
+  prompt/schema prototype: `/tmp/extract-receipt.sh` (recreate if gone —
+  fields: shopName/location, invoiceNumber, serviceDate, vehicle, odometer,
+  totalCost, lineItems[], suggestedTitle, recommendedWork).
+- Needs a `log_attachments` table (logId, path, contentType) — storage
+  layer already handles uploads.
+- `recommendedWork` (tech notes like "pads at 5mm, replace in 5k mi") can
+  prefill a reminder.
+- **In-app one-off scans (phase 2):** same schema via Cloudflare Workers
+  AI binding (free tier) so phone captures work without the Mac.
+- Deliberately NOT the Anthropic API — cost. Don't suggest it for this.
+
+### 2. Crew Chief MCP server
+
+So the crew can talk to Crew Chief from their own Claude accounts
+(claude.ai custom connector, works on mobile). NOTE: rally-specific
+features stay OUT of the app — the app is generic vehicle maintenance;
+rally procedure lives in Scott's external rebelle-rally skill, which will
+call these MCP tools:
 
 - Remote MCP endpoint at `/mcp` on the existing Worker — Cloudflare
   `agents` SDK (`McpAgent`) + `workers-oauth-provider`, OAuth backed by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ user-facing context and tool-choice rationale.
 ```sh
 npm run docker:dev      # start local Postgres (pgvector/pgvector:pg16 on :5440)
 npm run db:migrate      # apply Drizzle migrations
-npm run db:seed         # creates scott@example.com / scottiscool + seed vehicle
+npm run db:seed         # scott@example.com / scottiscool + vehicle, log, reminders, project
 npm run db:generate     # after schema changes
 npm run db:studio       # Drizzle Studio against local DB
 npm run dev             # Vite dev server on :3000
@@ -165,6 +165,24 @@ Remix/Prisma stack in places and are queued for a refresh pass.
 - `npm run build:node` (Nitro + TanStack Start node preset) produces
   `.output/server/index.mjs` but runtime 404s on all routes — SSR
   fallback wiring. Tracked for the self-host image release.
+
+## Next up: Crew Chief MCP server
+
+Planned (June 2026) so Scott's wife and her rally teammate can talk to
+Crew Chief from their own Claude accounts (claude.ai custom connector,
+works on mobile):
+
+- Remote MCP endpoint at `/mcp` on the existing Worker — Cloudflare
+  `agents` SDK (`McpAgent`) + `workers-oauth-provider`, OAuth backed by
+  the existing `users` table + session auth (login screen on connect; no
+  API keys for end users).
+- Tools are thin wrappers over `app/models/*` so crew-membership
+  authorization is enforced for free: `log_work`, `whats_due`,
+  `complete_reminder`, `get_vehicle_status`, `list_projects`,
+  `add_project_item`, `update_item_status`.
+- A rally-prep skill (Rebelle Rally — Scott has a draft) layers event
+  procedure on top and calls these tools; keep event-specific content in
+  the skill, generic data access in MCP.
 
 ## Documentation policy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ user-facing context and tool-choice rationale.
 npm run docker:dev      # start local Postgres (pgvector/pgvector:pg16 on :5440)
 npm run db:migrate      # apply Drizzle migrations
 npm run db:seed         # scott@example.com / scottiscool + vehicle, log, reminders, project
+npm run scan:extract -- <folder>            # Scan Bay: scans → review JSON (local Ollama)
+npm run scan:import -- <review.json> --vehicle <id> [--user <id>] [--reminders]
 npm run db:generate     # after schema changes
 npm run db:studio       # Drizzle Studio against local DB
 npm run dev             # Vite dev server on :3000
@@ -109,6 +111,7 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
 ## Files to know
 
 1. `app/db/schema.ts` — all tables + pgvector + tsvector setup
+   (incl. `log_attachments`: scans/photos/docs attached to a log)
 2. `app/db/client.ts` — postgres-js client, runtime-aware
 3. `app/db/migrations/` — generated SQL (do not edit by hand unless
    adding CREATE EXTENSION-style ops that Drizzle can't infer)
@@ -119,17 +122,22 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
    `member.server.ts` (crew/invites/access), `reminder.server.ts`
    (date+mileage due, recurring roll-forward), `project.server.ts`
    (builds + parts pipeline; status vocab in `project.shared.ts` because
-   client code can't import values from `.server.ts` modules)
-8. `app/routes/*` — file-based routes, including `/files/$` streaming
+   client code can't import values from `.server.ts` modules),
+   `attachment.server.ts` (log attachments — uploads via storage layer +
+   row insert, access checked against the log's vehicle)
+8. `app/scan/receipt.ts` — Scan Bay's isomorphic extraction contract (JSON
+   schema + prompt + `normalizeReceipt`/`receiptToNotes`), shared by the CLI
+   and the future Workers AI path. CLI lives in `scripts/scan-bay/`.
+9. `app/routes/*` — file-based routes, including `/files/$` streaming
    route and `/account/export` JSON bundle endpoint
-9. `wrangler.jsonc` — Cloudflare Workers config (Hyperdrive, R2, secrets)
-10. `drizzle.config.ts` — Drizzle Kit config
-11. `tsr.config.json` — TanStack Router CLI config; drives
+10. `wrangler.jsonc` — Cloudflare Workers config (Hyperdrive, R2, secrets)
+11. `drizzle.config.ts` — Drizzle Kit config
+12. `tsr.config.json` — TanStack Router CLI config; drives
     `app/routeTree.gen.ts` generation (the file is gitignored, so
     `npm run typecheck` regenerates it via `tsr generate` first)
-12. `biome.json` — lint/format rules
-13. `Dockerfile` + `docker/s6-rc.d/` — single-container self-host image
-14. `docker-compose.yml` — dev Postgres only (not for self-host)
+13. `biome.json` — lint/format rules
+14. `Dockerfile` + `docker/s6-rc.d/` — single-container self-host image
+15. `docker-compose.yml` — dev Postgres only (not for self-host)
 
 ## Git conventions
 
@@ -171,22 +179,21 @@ Remix/Prisma stack in places and are queued for a refresh pass.
 ### 1. Scan Bay — paper shop-record ingestion (local AI, $0)
 
 The app's core purpose is digitizing Scott's vehicle maintenance records,
-including a backlog of paper shop invoices. Plan validated against local
-hardware (M3 Pro / 18 GB, Ollama installed):
+including a backlog of paper shop invoices.
 
-- **Batch CLI** (`scripts/` + local Ollama `qwen3-vl:8b`, JSON-schema
-  structured output via `format` on `/api/chat`, temperature 0): folder of
-  scans → extracted JSON review file → import creates logs via the model
-  layer + stores the original scan with each log. Working extraction
-  prompt/schema prototype: `/tmp/extract-receipt.sh` (recreate if gone —
-  fields: shopName/location, invoiceNumber, serviceDate, vehicle, odometer,
-  totalCost, lineItems[], suggestedTitle, recommendedWork).
-- Needs a `log_attachments` table (logId, path, contentType) — storage
-  layer already handles uploads.
-- `recommendedWork` (tech notes like "pads at 5mm, replace in 5k mi") can
-  prefill a reminder.
-- **In-app one-off scans (phase 2):** same schema via Cloudflare Workers
-  AI binding (free tier) so phone captures work without the Mac.
+- **Phase 1 (DONE) — batch CLI.** `scripts/scan-bay/` + local Ollama
+  (`qwen3-vl:8b`, JSON-schema structured output via `format` on `/api/chat`,
+  temp 0). Two steps with a human review between: `npm run scan:extract --
+  <folder>` writes a `scan-review.json`; edit it; `npm run scan:import --
+  <review.json> --vehicle <id> [--reminders]` creates a log per invoice via
+  the model layer, stores the original scan as a `log_attachments` row, and
+  (with `--reminders`) drafts a reminder from `recommendedWork`. Idempotent —
+  imported entries are stamped with their logId. The extraction prompt +
+  schema + normalizer live in `app/scan/receipt.ts` (isomorphic, so phase 2
+  reuses them). Attachments render on the log detail page.
+- **Phase 2 (TODO) — in-app one-off scans:** same `app/scan/receipt.ts`
+  contract via the Cloudflare Workers AI binding (free tier) so phone
+  captures work without the Mac.
 - Deliberately NOT the Anthropic API — cost. Don't suggest it for this.
 
 ### 2. Crew Chief MCP server

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ npm run db:generate    # drizzle-kit generate (after schema changes)
 npm run db:migrate     # apply pending migrations
 npm run db:studio      # drizzle-kit studio
 npm run validate       # typecheck + lint + test (CI equivalent)
+npm run scan:extract -- <folder>          # Scan Bay: scans → review JSON
+npm run scan:import  -- <review.json> --vehicle <id>   # review JSON → logs
 ```
 
 ## Self-hosting
@@ -327,6 +329,43 @@ out of the client bundle.
 `schemaVersion` gives future importers a hook to evolve the format without
 breaking old bundles.
 
+## Scan Bay — digitizing paper records
+
+A big part of Crew Chief is getting a backlog of paper shop invoices into the
+app. Scan Bay does that locally, for **$0** — it runs a vision model on your own
+machine (Ollama + `qwen3-vl:8b` by default), so the receipts never leave your
+laptop and there's no per-page API cost.
+
+It's a two-step CLI with a human review in the middle:
+
+```sh
+# 1. Extract — read every image in a folder, write a review file
+npm run scan:extract -- ~/Desktop/jeep-receipts
+#   → ~/Desktop/jeep-receipts/scan-review.json
+
+# 2. Eyeball scan-review.json — fix a misread date, flip an entry's
+#    "status" to "skip" to exclude it. Then import:
+npm run scan:import -- ~/Desktop/jeep-receipts/scan-review.json \
+  --vehicle <vehicleId> --reminders
+```
+
+Each imported invoice becomes a work log (title, cost, odometer, service date,
+line items in the notes) with the **original scan stored as an attachment** on
+the log. `--reminders` also drafts a follow-up reminder from any recommended
+work the tech noted ("front pads at 5mm, replace in ~5k mi").
+
+Notes:
+
+- Requires [Ollama](https://ollama.com) running locally with a vision model:
+  `ollama pull qwen3-vl:8b`. Override with `OLLAMA_HOST` / `SCAN_MODEL`.
+- `import` is idempotent — entries are stamped `imported` with their log id,
+  so re-running the same review file is safe.
+- `--vehicle` targets the vehicle; the acting user defaults to that vehicle's
+  owner (override with `--user`). All writes go through the model layer, so
+  crew-access checks apply.
+- The extraction prompt + JSON schema live in `app/scan/receipt.ts`, shared so
+  the planned in-app one-off scan (Cloudflare Workers AI) extracts identically.
+
 ## Roadmap
 
 Near-term:
@@ -344,7 +383,11 @@ Near-term:
 
 Near-term, garage edition:
 
-- Photos on work logs (storage layer already handles uploads)
+- Scan Bay phase 2: in-app one-off scans via the Cloudflare Workers AI binding
+  (free tier) so phone captures work without the Mac — reuses
+  `app/scan/receipt.ts`
+- Photos on work logs (storage layer already handles uploads; the
+  `log_attachments` table from Scan Bay backs this)
 - Email/push notifications when a reminder goes overdue
 - Fuel tracking (fill-ups double as cheap odometer updates for reminders)
 - Printable maintenance history per vehicle (rally tech-inspection sheet)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ image.
 | Cloud deploy         | Cloudflare Workers + Hyperdrive + Neon + R2  |
 | Self-host deploy     | Single Docker image (app + Postgres + data volume) |
 | Lint / format        | [Biome 2](https://biomejs.dev)                |
-| Tests                | Vitest (integration), Playwright (planned)   |
+| Tests                | Vitest (integration), Playwright e2e smoke tests |
 | Auth                 | Cookie session via TanStack Start `useSession` + bcryptjs |
 | Styling              | Tailwind v4                                  |
 
@@ -331,8 +331,10 @@ breaking old bundles.
 
 Near-term:
 
-- Playwright e2e coverage for login → vehicle → avatar upload → log → export
-  flows
+- Extend Playwright e2e coverage to avatar upload, export, crew invites,
+  and reminder completion (registration/login/vehicle/log flows are covered)
+- MCP server on the Worker (`/mcp`) so the crew can log work and check
+  what's due from their own Claude accounts — OAuth against existing users
 - Finalize the single-container self-host image and publish the first GHCR
   release
 - Fix the Nitro 3 + TanStack Start node-build integration so `npm run build:node`

--- a/app/db/migrations/0003_overrated_emma_frost.sql
+++ b/app/db/migrations/0003_overrated_emma_frost.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "log_attachments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"log_id" text NOT NULL,
+	"path" text NOT NULL,
+	"content_type" text NOT NULL,
+	"original_name" text,
+	"kind" text DEFAULT 'scan' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "log_attachments" ADD CONSTRAINT "log_attachments_log_id_logs_id_fk" FOREIGN KEY ("log_id") REFERENCES "public"."logs"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+CREATE INDEX "log_attachments_log_idx" ON "log_attachments" USING btree ("log_id");

--- a/app/db/migrations/meta/0003_snapshot.json
+++ b/app/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1352 @@
+{
+  "id": "76afaeb1-e0b9-4e67-9b1f-844e534f44d7",
+  "prevId": "089c7914-a113-4b4d-98a8-54f25b5fbcd1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.log_attachments": {
+      "name": "log_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "log_attachments_log_idx": {
+          "name": "log_attachments_log_idx",
+          "columns": [
+            {
+              "expression": "log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "log_attachments_log_id_logs_id_fk": {
+          "name": "log_attachments_log_id_logs_id_fk",
+          "tableFrom": "log_attachments",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serviced_at": {
+          "name": "serviced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "self_service": {
+          "name": "self_service",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mechanic_id": {
+          "name": "mechanic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(\"logs\".\"title\", '') || ' ' || coalesce(\"logs\".\"notes\", ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_search_idx": {
+          "name": "logs_search_idx",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "logs_vehicle_idx": {
+          "name": "logs_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_user_idx": {
+          "name": "logs_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "logs_user_id_users_id_fk": {
+          "name": "logs_user_id_users_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "logs_vehicle_id_vehicles_id_fk": {
+          "name": "logs_vehicle_id_vehicles_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "logs_mechanic_id_mechanics_id_fk": {
+          "name": "logs_mechanic_id_mechanics_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "mechanics",
+          "columnsFrom": [
+            "mechanic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_to_parts": {
+      "name": "logs_to_parts",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logs_to_parts_log_id_logs_id_fk": {
+          "name": "logs_to_parts_log_id_logs_id_fk",
+          "tableFrom": "logs_to_parts",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "logs_to_parts_part_id_parts_id_fk": {
+          "name": "logs_to_parts_part_id_parts_id_fk",
+          "tableFrom": "logs_to_parts",
+          "tableTo": "parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "logs_to_parts_log_id_part_id_pk": {
+          "name": "logs_to_parts_log_id_part_id_pk",
+          "columns": [
+            "log_id",
+            "part_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_to_tags": {
+      "name": "logs_to_tags",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logs_to_tags_log_id_logs_id_fk": {
+          "name": "logs_to_tags_log_id_logs_id_fk",
+          "tableFrom": "logs_to_tags",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "logs_to_tags_tag_id_tags_id_fk": {
+          "name": "logs_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "logs_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "logs_to_tags_log_id_tag_id_pk": {
+          "name": "logs_to_tags_log_id_tag_id_pk",
+          "columns": [
+            "log_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mechanics": {
+      "name": "mechanics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mechanics_email_idx": {
+          "name": "mechanics_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parts": {
+      "name": "parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passwords": {
+      "name": "passwords",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passwords_user_id_users_id_fk": {
+          "name": "passwords_user_id_users_id_fk",
+          "tableFrom": "passwords",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passwords_user_id_unique": {
+          "name": "passwords_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_items": {
+      "name": "project_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_items_project_idx": {
+          "name": "project_items_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_items_project_id_projects_id_fk": {
+          "name": "project_items_project_id_projects_id_fk",
+          "tableFrom": "project_items",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idea'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_vehicle_idx": {
+          "name": "projects_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_vehicle_id_vehicles_id_fk": {
+          "name": "projects_vehicle_id_vehicles_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "projects_created_by_id_users_id_fk": {
+          "name": "projects_created_by_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reminders": {
+      "name": "reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_miles": {
+          "name": "due_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_months": {
+          "name": "interval_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_miles": {
+          "name": "interval_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reminders_vehicle_idx": {
+          "name": "reminders_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reminders_vehicle_id_vehicles_id_fk": {
+          "name": "reminders_vehicle_id_vehicles_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "reminders_created_by_id_users_id_fk": {
+          "name": "reminders_created_by_id_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_invites": {
+      "name": "vehicle_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_invites_vehicle_email_idx": {
+          "name": "vehicle_invites_vehicle_email_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vehicle_invites_email_idx": {
+          "name": "vehicle_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_invites_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_invites_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_invites",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_invites_invited_by_id_users_id_fk": {
+          "name": "vehicle_invites_invited_by_id_users_id_fk",
+          "tableFrom": "vehicle_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_members": {
+      "name": "vehicle_members",
+      "schema": "",
+      "columns": {
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_members_user_idx": {
+          "name": "vehicle_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_members_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_members_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_members",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_members_user_id_users_id_fk": {
+          "name": "vehicle_members_user_id_users_id_fk",
+          "tableFrom": "vehicle_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vehicle_members_vehicle_id_user_id_pk": {
+          "name": "vehicle_members_vehicle_id_user_id_pk",
+          "columns": [
+            "vehicle_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trim": {
+          "name": "trim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vehicles_user_id_users_id_fk": {
+          "name": "vehicles_user_id_users_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/db/migrations/meta/_journal.json
+++ b/app/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781154272988,
       "tag": "0002_supreme_dreaming_celestial",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781160232622,
+      "tag": "0003_overrated_emma_frost",
+      "breakpoints": true
     }
   ]
 }

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -242,6 +242,25 @@ export const projectItems = pgTable(
   (t) => [index("project_items_project_idx").on(t.projectId)],
 );
 
+// Files attached to a log — primarily the original scanned shop invoice
+// ingested by Scan Bay, but also phone photos or PDFs. `path` is a storage
+// key (see app/storage.server.ts); `kind` distinguishes provenance.
+export const logAttachments = pgTable(
+  "log_attachments",
+  {
+    id: cuid2().primaryKey(),
+    logId: text("log_id")
+      .notNull()
+      .references(() => logs.id, { onDelete: "cascade", onUpdate: "cascade" }),
+    path: text().notNull(),
+    contentType: text("content_type").notNull(),
+    originalName: text("original_name"),
+    kind: text().notNull().default("scan"), // "scan" | "photo" | "doc"
+    ...timestamps,
+  },
+  (t) => [index("log_attachments_log_idx").on(t.logId)],
+);
+
 export const tags = pgTable(
   "tags",
   {
@@ -303,3 +322,5 @@ export type Project = typeof projects.$inferSelect;
 export type NewProject = typeof projects.$inferInsert;
 export type ProjectItem = typeof projectItems.$inferSelect;
 export type NewProjectItem = typeof projectItems.$inferInsert;
+export type LogAttachment = typeof logAttachments.$inferSelect;
+export type NewLogAttachment = typeof logAttachments.$inferInsert;

--- a/app/models/attachment.server.test.ts
+++ b/app/models/attachment.server.test.ts
@@ -1,0 +1,118 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createDb } from "~/db/client";
+import { users } from "~/db/schema";
+import {
+  addLogAttachment,
+  listLogAttachments,
+} from "~/models/attachment.server";
+import { createLog } from "~/models/log.server";
+import { createVehicle } from "~/models/vehicle.server";
+import type { Storage, StoredFile } from "~/storage.server";
+
+// Integration test — requires DATABASE_URL pointing at a running local Postgres
+// with migrations applied. Storage is stubbed so we don't touch the filesystem.
+
+const url = process.env.DATABASE_URL;
+if (!url) throw new Error("DATABASE_URL is required for attachment test");
+
+const { db, close } = createDb(url);
+
+/** In-memory Storage so the test never hits disk or R2. */
+class MemoryStorage implements Storage {
+  readonly files = new Map<string, StoredFile>();
+  async upload(
+    key: string,
+    body: Uint8Array | ArrayBuffer,
+    contentType: string,
+  ) {
+    const bytes = body instanceof Uint8Array ? body : new Uint8Array(body);
+    this.files.set(key, { body: bytes, contentType });
+  }
+  async read(key: string) {
+    return this.files.get(key) ?? null;
+  }
+  async exists(key: string) {
+    return this.files.has(key);
+  }
+}
+
+let userId: string;
+let vehicleId: string;
+let logId: string;
+
+beforeAll(async () => {
+  const [user] = await db
+    .insert(users)
+    .values({ email: `attach-test-${Date.now()}@example.com` })
+    .returning();
+  if (!user) throw new Error("user insert failed");
+  userId = user.id;
+
+  const vehicle = await createVehicle({
+    userId,
+    make: "Test",
+    model: "Vehicle",
+    year: 2020,
+  });
+  vehicleId = vehicle.id;
+
+  const log = await createLog({ userId, vehicleId, title: "Shop service" });
+  logId = log.id;
+});
+
+afterAll(async () => {
+  await db.delete(users).where(eq(users.id, userId));
+  await close();
+});
+
+describe("log attachments", () => {
+  it("uploads bytes and records the attachment", async () => {
+    const storage = new MemoryStorage();
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+
+    const attachment = await addLogAttachment({
+      logId,
+      vehicleId,
+      userId,
+      body: bytes,
+      contentType: "image/png",
+      originalName: "Receipt #42.png",
+      storage,
+    });
+
+    expect(attachment.logId).toBe(logId);
+    expect(attachment.contentType).toBe("image/png");
+    expect(attachment.path.startsWith(`attachments/${logId}/`)).toBe(true);
+    // Filename is slugified into the storage key.
+    expect(attachment.path).toContain("receipt-42.png");
+    expect(storage.files.get(attachment.path)?.body).toEqual(bytes);
+
+    const list = await listLogAttachments({ logId, vehicleId, userId });
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe(attachment.id);
+  });
+
+  it("rejects attaching to a log on a vehicle the user can't access", async () => {
+    const [stranger] = await db
+      .insert(users)
+      .values({ email: `attach-stranger-${Date.now()}@example.com` })
+      .returning();
+    if (!stranger) throw new Error("stranger insert failed");
+    try {
+      await expect(
+        addLogAttachment({
+          logId,
+          vehicleId,
+          userId: stranger.id,
+          body: new Uint8Array([0]),
+          contentType: "image/png",
+          storage: new MemoryStorage(),
+        }),
+      ).rejects.toThrow("Vehicle not found");
+    } finally {
+      await db.delete(users).where(eq(users.id, stranger.id));
+    }
+  });
+});

--- a/app/models/attachment.server.ts
+++ b/app/models/attachment.server.ts
@@ -1,0 +1,105 @@
+import { createId } from "@paralleldrive/cuid2";
+import { and, asc, eq } from "drizzle-orm";
+
+import { getDb } from "~/db/client";
+import type { LogAttachment } from "~/db/schema";
+import { logAttachments, logs } from "~/db/schema";
+import { requireVehicleAccess } from "~/models/member.server";
+import { getStorage, type Storage } from "~/storage.server";
+
+export type { LogAttachment };
+
+/** Strip a filename to a storage-key-safe slug, preserving the extension. */
+function safeName(name: string | null | undefined): string {
+  if (!name) return "scan";
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9.]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug.slice(0, 80) : "scan";
+}
+
+/**
+ * Confirm the log exists on a vehicle the user can access. Attachments are
+ * always reached through their log, so access is the log's access.
+ */
+async function requireLogAccess({
+  logId,
+  vehicleId,
+  userId,
+}: {
+  logId: string;
+  vehicleId: string;
+  userId: string;
+}): Promise<void> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const [row] = await db
+    .select({ id: logs.id })
+    .from(logs)
+    .where(and(eq(logs.id, logId), eq(logs.vehicleId, vehicleId)));
+  if (!row) throw new Error("Log not found");
+}
+
+/**
+ * Store a file (the original scan, a photo, a PDF) and attach it to a log.
+ * Uploads the bytes to the storage driver under a per-log key, then records
+ * the row. Access is checked against the log's vehicle.
+ */
+export async function addLogAttachment({
+  logId,
+  vehicleId,
+  userId,
+  body,
+  contentType,
+  originalName,
+  kind = "scan",
+  storage = getStorage(),
+}: {
+  logId: string;
+  vehicleId: string;
+  userId: string;
+  body: Uint8Array | ArrayBuffer;
+  contentType: string;
+  originalName?: string | null;
+  kind?: string;
+  /** Override the storage driver (tests, or an explicit R2 binding). */
+  storage?: Storage;
+}): Promise<LogAttachment> {
+  await requireLogAccess({ logId, vehicleId, userId });
+
+  const key = `attachments/${logId}/${createId()}-${safeName(originalName)}`;
+  await storage.upload(key, body, contentType);
+
+  const db = await getDb();
+  const [attachment] = await db
+    .insert(logAttachments)
+    .values({
+      logId,
+      path: key,
+      contentType,
+      originalName: originalName ?? null,
+      kind,
+    })
+    .returning();
+  if (!attachment) throw new Error("Failed to create attachment");
+  return attachment;
+}
+
+export async function listLogAttachments({
+  logId,
+  vehicleId,
+  userId,
+}: {
+  logId: string;
+  vehicleId: string;
+  userId: string;
+}): Promise<LogAttachment[]> {
+  await requireLogAccess({ logId, vehicleId, userId });
+  const db = await getDb();
+  return db
+    .select()
+    .from(logAttachments)
+    .where(eq(logAttachments.logId, logId))
+    .orderBy(asc(logAttachments.createdAt));
+}

--- a/app/routes/_authed.vehicles.$vehicleId.logs.$logId.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.logs.$logId.tsx
@@ -9,13 +9,25 @@ import { createServerFn } from "@tanstack/react-start";
 
 import { requireAuth } from "~/auth/session.server";
 import { card } from "~/components/ui";
+import { listLogAttachments } from "~/models/attachment.server";
 import { deleteLog, getLog } from "~/models/log.server";
 
 const loadLogFn = createServerFn({ method: "GET" })
   .inputValidator((input: { vehicleId: string; logId: string }) => input)
   .handler(async ({ data }) => {
     const userId = await requireAuth();
-    return getLog({ id: data.logId, userId, vehicleId: data.vehicleId });
+    const log = await getLog({
+      id: data.logId,
+      userId,
+      vehicleId: data.vehicleId,
+    });
+    if (!log) return null;
+    const attachments = await listLogAttachments({
+      logId: data.logId,
+      vehicleId: data.vehicleId,
+      userId,
+    });
+    return { ...log, attachments };
   });
 
 const deleteLogFn = createServerFn({ method: "POST" })
@@ -101,6 +113,42 @@ function LogDetail() {
           </dd>
         </div>
       </dl>
+      {log.attachments.length > 0 ? (
+        <div className="mt-6">
+          <h3 className="text-sm font-semibold text-ink-muted">
+            Scans & attachments
+          </h3>
+          <ul className="mt-2 flex flex-wrap gap-3">
+            {log.attachments.map((att) => {
+              const href = `/files/${att.path}`;
+              const isImage = att.contentType.startsWith("image/");
+              return (
+                <li key={att.id}>
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={`${card} block overflow-hidden transition-colors hover:bg-sunken`}
+                    title={att.originalName ?? "Attachment"}
+                  >
+                    {isImage ? (
+                      <img
+                        src={href}
+                        alt={att.originalName ?? "Scan"}
+                        className="h-32 w-32 object-cover"
+                      />
+                    ) : (
+                      <span className="flex h-32 w-32 items-center justify-center text-4xl">
+                        📄
+                      </span>
+                    )}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/app/scan/receipt.test.ts
+++ b/app/scan/receipt.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ExtractedReceipt,
+  normalizeReceipt,
+  receiptToNotes,
+} from "~/scan/receipt";
+
+describe("normalizeReceipt", () => {
+  it("passes through a well-formed receipt", () => {
+    const result = normalizeReceipt({
+      shopName: "Joe's Auto",
+      shopLocation: "Reno, NV",
+      invoiceNumber: "A-1234",
+      serviceDate: "2026-01-15",
+      vehicle: "2018 Jeep Wrangler",
+      odometer: 48210,
+      totalCost: 412.55,
+      lineItems: [
+        { description: "Synthetic oil change", quantity: 1, total: 89.99 },
+        { description: "Brake inspection", quantity: 1, total: 0 },
+      ],
+      suggestedTitle: "Oil change + brake inspection",
+      recommendedWork: "Front pads at 5mm, replace in ~5k mi",
+    });
+
+    expect(result.shopName).toBe("Joe's Auto");
+    expect(result.odometer).toBe(48210);
+    expect(result.totalCost).toBe(412.55);
+    expect(result.lineItems).toHaveLength(2);
+    expect(result.serviceDate).toBe("2026-01-15");
+  });
+
+  it("coerces money/odometer strings with symbols and commas", () => {
+    const result = normalizeReceipt({
+      odometer: "48,210 mi",
+      totalCost: "$1,299.00",
+      suggestedTitle: "Major service",
+      lineItems: [{ description: "Timing belt", total: "$899.00" }],
+    });
+
+    expect(result.odometer).toBe(48210);
+    expect(result.totalCost).toBe(1299);
+    expect(result.lineItems[0]?.total).toBe(899);
+  });
+
+  it("nulls out empty/whitespace strings and unparseable numbers", () => {
+    const result = normalizeReceipt({
+      shopName: "   ",
+      odometer: "n/a",
+      totalCost: null,
+      suggestedTitle: "Service",
+      lineItems: [],
+    });
+
+    expect(result.shopName).toBeNull();
+    expect(result.odometer).toBeNull();
+    expect(result.totalCost).toBeNull();
+  });
+
+  it("drops line items without a description", () => {
+    const result = normalizeReceipt({
+      suggestedTitle: "Service",
+      lineItems: [
+        { description: "Air filter", total: 24 },
+        { description: "", total: 10 },
+        { total: 99 },
+        "garbage",
+      ],
+    });
+
+    expect(result.lineItems).toHaveLength(1);
+    expect(result.lineItems[0]?.description).toBe("Air filter");
+  });
+
+  it("normalizes non-ISO dates to YYYY-MM-DD and keeps the date part of ISO", () => {
+    expect(
+      normalizeReceipt({ serviceDate: "2026-03-09T00:00:00Z" }).serviceDate,
+    ).toBe("2026-03-09");
+    expect(normalizeReceipt({ serviceDate: "01/15/2026" }).serviceDate).toBe(
+      "2026-01-15",
+    );
+    expect(
+      normalizeReceipt({ serviceDate: "not a date" }).serviceDate,
+    ).toBeNull();
+  });
+
+  it("never throws on junk and always supplies a title", () => {
+    expect(normalizeReceipt(null).suggestedTitle).toBe("Shop service");
+    expect(normalizeReceipt(undefined).lineItems).toEqual([]);
+    expect(normalizeReceipt("string").suggestedTitle).toBe("Shop service");
+    expect(normalizeReceipt({ suggestedTitle: 42 }).suggestedTitle).toBe(
+      "Shop service",
+    );
+  });
+});
+
+describe("receiptToNotes", () => {
+  const base: ExtractedReceipt = {
+    shopName: null,
+    shopLocation: null,
+    invoiceNumber: null,
+    serviceDate: null,
+    vehicle: null,
+    odometer: null,
+    totalCost: null,
+    lineItems: [],
+    suggestedTitle: "Service",
+    recommendedWork: null,
+  };
+
+  it("renders line items, recommended work, and provenance", () => {
+    const notes = receiptToNotes({
+      ...base,
+      shopName: "Joe's Auto",
+      shopLocation: "Reno, NV",
+      invoiceNumber: "A-1234",
+      lineItems: [
+        { description: "Oil change", quantity: 1, total: 89.99 },
+        { description: "Wiper blades", quantity: 2, total: 24 },
+      ],
+      recommendedWork: "Rotate tires next visit",
+    });
+
+    expect(notes).toContain("• 1× Oil change — $89.99");
+    expect(notes).toContain("• 2× Wiper blades — $24.00");
+    expect(notes).toContain("Recommended: Rotate tires next visit");
+    expect(notes).toContain("Joe's Auto · Reno, NV · Invoice A-1234");
+  });
+
+  it("returns an empty string when there's nothing to say", () => {
+    expect(receiptToNotes(base)).toBe("");
+  });
+});

--- a/app/scan/receipt.ts
+++ b/app/scan/receipt.ts
@@ -1,0 +1,191 @@
+/**
+ * Scan Bay — shared receipt-extraction contract.
+ *
+ * This module is deliberately isomorphic (no server/runtime imports) so the
+ * exact same prompt + JSON schema drive both ingestion paths:
+ *   1. the local batch CLI (Ollama `qwen3-vl`, `scripts/scan-bay/`), and
+ *   2. the future in-app one-off scan (Cloudflare Workers AI binding).
+ *
+ * Keep the schema, the prompt, and `normalizeReceipt()` in lockstep — the
+ * schema is what we hand the model's structured-output mode; normalize is the
+ * trust-nothing pass we run on whatever comes back before it touches the DB.
+ */
+
+export type ExtractedLineItem = {
+  description: string;
+  quantity: number | null;
+  total: number | null;
+};
+
+export type ExtractedReceipt = {
+  shopName: string | null;
+  shopLocation: string | null;
+  invoiceNumber: string | null;
+  /** ISO `YYYY-MM-DD`, or null when not legible. */
+  serviceDate: string | null;
+  /** Free-text vehicle description as printed on the invoice. */
+  vehicle: string | null;
+  odometer: number | null;
+  totalCost: number | null;
+  lineItems: ExtractedLineItem[];
+  /** A short human title for the log, e.g. "Major service + brakes". */
+  suggestedTitle: string;
+  /** Tech notes about future/recommended work, e.g. "pads at 5mm". */
+  recommendedWork: string | null;
+};
+
+/**
+ * JSON Schema handed to the model's structured-output mode (`format` on
+ * Ollama's `/api/chat`, or the response_format on Workers AI). Nullable fields
+ * use the `["string", "null"]` union the local models honor most reliably.
+ */
+export const RECEIPT_JSON_SCHEMA = {
+  type: "object",
+  properties: {
+    shopName: { type: ["string", "null"] },
+    shopLocation: { type: ["string", "null"] },
+    invoiceNumber: { type: ["string", "null"] },
+    serviceDate: { type: ["string", "null"] },
+    vehicle: { type: ["string", "null"] },
+    odometer: { type: ["number", "null"] },
+    totalCost: { type: ["number", "null"] },
+    lineItems: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          description: { type: "string" },
+          quantity: { type: ["number", "null"] },
+          total: { type: ["number", "null"] },
+        },
+        required: ["description"],
+      },
+    },
+    suggestedTitle: { type: "string" },
+    recommendedWork: { type: ["string", "null"] },
+  },
+  required: [
+    "shopName",
+    "serviceDate",
+    "totalCost",
+    "lineItems",
+    "suggestedTitle",
+  ],
+} as const;
+
+export const EXTRACTION_PROMPT =
+  "Extract the data from this auto-shop invoice/receipt. Use null for " +
+  "anything not present. odometer should be the odometer-in reading if both " +
+  "in/out are shown. totalCost is the final amount paid. serviceDate in " +
+  "YYYY-MM-DD. recommendedWork captures any tech notes about future or " +
+  "recommended service.";
+
+/** Coerce a value to a finite number, or null. Strips `$`, commas, units. */
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.-]/g, "");
+    if (!cleaned) return null;
+    const n = Number.parseFloat(cleaned);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/** Trim a string and collapse empty/whitespace-only to null. */
+function toText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Normalize a date-ish value to ISO `YYYY-MM-DD`, or null if unparseable. */
+function toIsoDate(value: unknown): string | null {
+  const text = toText(value);
+  if (!text) return null;
+  // Already ISO-ish? Keep the date part verbatim — avoids TZ drift.
+  const iso = /^(\d{4}-\d{2}-\d{2})/.exec(text);
+  if (iso) return iso[1] ?? null;
+  const parsed = new Date(text);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString().slice(0, 10);
+}
+
+/**
+ * Defensive normalizer: takes whatever the model returned (already parsed
+ * JSON) and produces a well-typed `ExtractedReceipt`. Never throws — missing
+ * or malformed fields become null / empty so import can proceed and the human
+ * can fill gaps. The only invented value is `suggestedTitle`, which falls back
+ * to a generic label so every log has a title.
+ */
+export function normalizeReceipt(raw: unknown): ExtractedReceipt {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<
+    string,
+    unknown
+  >;
+
+  const lineItems: ExtractedLineItem[] = Array.isArray(r.lineItems)
+    ? r.lineItems
+        .map((item) => {
+          const it = (item && typeof item === "object" ? item : {}) as Record<
+            string,
+            unknown
+          >;
+          const description = toText(it.description);
+          if (!description) return null;
+          return {
+            description,
+            quantity: toNumber(it.quantity),
+            total: toNumber(it.total),
+          };
+        })
+        .filter((x): x is ExtractedLineItem => x !== null)
+    : [];
+
+  return {
+    shopName: toText(r.shopName),
+    shopLocation: toText(r.shopLocation),
+    invoiceNumber: toText(r.invoiceNumber),
+    serviceDate: toIsoDate(r.serviceDate),
+    vehicle: toText(r.vehicle),
+    odometer: toNumber(r.odometer),
+    totalCost: toNumber(r.totalCost),
+    lineItems,
+    suggestedTitle: toText(r.suggestedTitle) ?? "Shop service",
+    recommendedWork: toText(r.recommendedWork),
+  };
+}
+
+/**
+ * Compose a log's notes body from the extracted receipt — line items as a
+ * bulleted list, plus shop/invoice provenance and any recommended work. Shared
+ * by the importer so both ingestion paths render notes identically.
+ */
+export function receiptToNotes(receipt: ExtractedReceipt): string {
+  const parts: string[] = [];
+
+  if (receipt.lineItems.length > 0) {
+    parts.push(
+      receipt.lineItems
+        .map((item) => {
+          const qty = item.quantity != null ? `${item.quantity}× ` : "";
+          const cost = item.total != null ? ` — $${item.total.toFixed(2)}` : "";
+          return `• ${qty}${item.description}${cost}`;
+        })
+        .join("\n"),
+    );
+  }
+
+  if (receipt.recommendedWork) {
+    parts.push(`Recommended: ${receipt.recommendedWork}`);
+  }
+
+  const provenance: string[] = [];
+  if (receipt.shopName) provenance.push(receipt.shopName);
+  if (receipt.shopLocation) provenance.push(receipt.shopLocation);
+  if (receipt.invoiceNumber)
+    provenance.push(`Invoice ${receipt.invoiceNumber}`);
+  if (provenance.length > 0) parts.push(provenance.join(" · "));
+
+  return parts.join("\n\n");
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:seed": "node --env-file=.env --import tsx app/db/seed.ts",
+    "scan:extract": "node --import tsx scripts/scan-bay/scan.ts",
+    "scan:import": "node --env-file=.env --import tsx scripts/scan-bay/import.ts",
     "docker:dev": "docker compose up -d",
     "docker:build": "docker build -t crew-chief:local .",
     "validate": "npm run typecheck && npm run lint && npm run test -- --run"

--- a/scripts/scan-bay/import.ts
+++ b/scripts/scan-bay/import.ts
@@ -1,0 +1,147 @@
+/**
+ * Scan Bay step 2 — import.
+ *
+ *   npm run scan:import -- <review.json> --vehicle <id> [--user <id>]
+ *                            [--reminders]
+ *
+ * Reads a review file produced by `scan:extract` and, for each "pending"
+ * entry, creates a log via the model layer (so crew-access checks apply),
+ * stores the original scan as a log attachment, and — with --reminders —
+ * drafts a reminder from the tech's recommended-work note.
+ *
+ * Idempotent: imported entries are stamped with their logId and status
+ * "imported", and the review file is rewritten, so re-running skips them.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+import { eq } from "drizzle-orm";
+
+import { getDb } from "~/db/client";
+import { vehicles } from "~/db/schema";
+import { addLogAttachment } from "~/models/attachment.server.ts";
+import { createLog } from "~/models/log.server.ts";
+import { createReminder } from "~/models/reminder.server.ts";
+import { receiptToNotes } from "~/scan/receipt.ts";
+import { contentTypeFor, type ReviewFile } from "./review.ts";
+
+type Args = {
+  reviewPath: string;
+  vehicleId: string;
+  userId?: string;
+  reminders: boolean;
+};
+
+function parseArgs(argv: string[]): Args {
+  const positional: string[] = [];
+  let vehicleId: string | undefined;
+  let userId: string | undefined;
+  let reminders = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--vehicle") vehicleId = argv[++i];
+    else if (arg === "--user") userId = argv[++i];
+    else if (arg === "--reminders") reminders = true;
+    else if (arg?.startsWith("--")) throw new Error(`Unknown flag: ${arg}`);
+    else if (arg) positional.push(arg);
+  }
+
+  const reviewPath = positional[0];
+  if (!reviewPath || !vehicleId) {
+    throw new Error(
+      "Usage: scan:import -- <review.json> --vehicle <id> [--user <id>] [--reminders]",
+    );
+  }
+  return { reviewPath: resolve(reviewPath), vehicleId, userId, reminders };
+}
+
+/** Resolve the acting user — explicit --user, else the vehicle's owner. */
+async function resolveUserId(
+  vehicleId: string,
+  explicit: string | undefined,
+): Promise<string> {
+  if (explicit) return explicit;
+  const db = await getDb();
+  const [vehicle] = await db
+    .select({ userId: vehicles.userId })
+    .from(vehicles)
+    .where(eq(vehicles.id, vehicleId));
+  if (!vehicle) throw new Error(`Vehicle ${vehicleId} not found`);
+  return vehicle.userId;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const userId = await resolveUserId(args.vehicleId, args.userId);
+
+  const raw = await readFile(args.reviewPath, "utf8");
+  const review = JSON.parse(raw) as ReviewFile;
+  const reviewDir = dirname(args.reviewPath);
+
+  let imported = 0;
+  let skipped = 0;
+
+  for (const entry of review.entries) {
+    if (entry.status !== "pending" || !entry.extracted) {
+      skipped++;
+      continue;
+    }
+    const r = entry.extracted;
+
+    const log = await createLog({
+      userId,
+      vehicleId: args.vehicleId,
+      title: r.suggestedTitle,
+      notes: receiptToNotes(r) || null,
+      type: null,
+      cost: r.totalCost,
+      odometer: r.odometer,
+      servicedAt: r.serviceDate ? new Date(r.serviceDate) : new Date(),
+      selfService: false,
+    });
+
+    // Store the original scan alongside the log.
+    const scanPath = resolve(reviewDir, entry.file);
+    const contentType =
+      contentTypeFor(entry.file) ?? "application/octet-stream";
+    const bytes = await readFile(scanPath);
+    await addLogAttachment({
+      logId: log.id,
+      vehicleId: args.vehicleId,
+      userId,
+      body: new Uint8Array(bytes),
+      contentType,
+      originalName: entry.file,
+      kind: "scan",
+    });
+
+    // Draft a reminder from the tech's recommended-work note.
+    if (args.reminders && r.recommendedWork) {
+      await createReminder({
+        userId,
+        vehicleId: args.vehicleId,
+        title: `Follow-up: ${r.suggestedTitle}`,
+        notes: r.recommendedWork,
+      });
+    }
+
+    entry.status = "imported";
+    entry.logId = log.id;
+    imported++;
+    console.log(`  ✓ ${entry.file} → log ${log.id} (${r.suggestedTitle})`);
+  }
+
+  await writeFile(args.reviewPath, `${JSON.stringify(review, null, 2)}\n`);
+  console.log(
+    `\n[import] ${imported} log(s) created, ${skipped} skipped. ` +
+      `Updated ${args.reviewPath}.`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/scan-bay/ollama.ts
+++ b/scripts/scan-bay/ollama.ts
@@ -1,0 +1,81 @@
+/**
+ * Scan Bay — local extraction via Ollama's `/api/chat` with structured output.
+ *
+ * Deliberately NOT the Anthropic API: this runs against a local vision model
+ * (default `qwen3-vl:8b`) so digitizing Scott's paper invoice backlog costs
+ * $0. The schema + prompt come from the shared `~/scan/receipt` contract so
+ * the in-app Workers AI path can extract identically later.
+ */
+
+import { Buffer } from "node:buffer";
+
+import {
+  EXTRACTION_PROMPT,
+  type ExtractedReceipt,
+  normalizeReceipt,
+  RECEIPT_JSON_SCHEMA,
+} from "~/scan/receipt.ts";
+
+export type OllamaConfig = {
+  host: string;
+  model: string;
+};
+
+export const DEFAULT_OLLAMA: OllamaConfig = {
+  host: process.env.OLLAMA_HOST ?? "http://localhost:11434",
+  model: process.env.SCAN_MODEL ?? "qwen3-vl:8b",
+};
+
+type OllamaChatResponse = {
+  message?: { content?: string };
+  error?: string;
+};
+
+/**
+ * Run one image through the model and return a normalized receipt. Throws on
+ * transport/model errors; the caller decides how to record a failed scan.
+ */
+export async function extractReceipt(
+  image: Uint8Array,
+  config: OllamaConfig = DEFAULT_OLLAMA,
+): Promise<ExtractedReceipt> {
+  const base64 = Buffer.from(image).toString("base64");
+
+  const res = await fetch(`${config.host}/api/chat`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: config.model,
+      stream: false,
+      messages: [
+        { role: "user", content: EXTRACTION_PROMPT, images: [base64] },
+      ],
+      format: RECEIPT_JSON_SCHEMA,
+      options: { temperature: 0 },
+    }),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(
+      `Ollama ${res.status} ${res.statusText}${detail ? `: ${detail}` : ""}`,
+    );
+  }
+
+  const data = (await res.json()) as OllamaChatResponse;
+  if (data.error) throw new Error(`Ollama error: ${data.error}`);
+
+  const content = data.message?.content;
+  if (!content) throw new Error("Ollama returned an empty response");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error(
+      `Model did not return valid JSON: ${content.slice(0, 200)}`,
+    );
+  }
+
+  return normalizeReceipt(parsed);
+}

--- a/scripts/scan-bay/review.ts
+++ b/scripts/scan-bay/review.ts
@@ -1,0 +1,52 @@
+/**
+ * Scan Bay — the review-file format that bridges the two CLI steps.
+ *
+ * `scan` writes one of these; a human eyeballs/edits it (fix a date, flip an
+ * entry's status to "skip"); then `import` reads it and creates the logs. The
+ * file is intentionally plain JSON so it's easy to hand-correct.
+ */
+
+import { extname } from "node:path";
+
+import type { ExtractedReceipt } from "~/scan/receipt.ts";
+
+export type ReviewStatus = "pending" | "skip" | "imported";
+
+export type ReviewEntry = {
+  /** Path to the scan, relative to the review file's directory. */
+  file: string;
+  status: ReviewStatus;
+  /** Extraction error, when the model/transport failed for this file. */
+  error?: string;
+  /** Set by `import` once the log exists, so re-runs don't duplicate. */
+  logId?: string;
+  extracted: ExtractedReceipt | null;
+};
+
+export type ReviewFile = {
+  version: 1;
+  createdAt: string;
+  sourceDir: string;
+  model: string;
+  entries: ReviewEntry[];
+};
+
+/** Image extensions the vision model can read. PDFs aren't supported. */
+const CONTENT_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+  ".bmp": "image/bmp",
+};
+
+export const SCAN_EXTENSIONS = Object.keys(CONTENT_TYPES);
+
+export function contentTypeFor(file: string): string | null {
+  return CONTENT_TYPES[extname(file).toLowerCase()] ?? null;
+}
+
+export function isScannable(file: string): boolean {
+  return contentTypeFor(file) !== null;
+}

--- a/scripts/scan-bay/scan.ts
+++ b/scripts/scan-bay/scan.ts
@@ -1,0 +1,107 @@
+/**
+ * Scan Bay step 1 — extract.
+ *
+ *   npm run scan:extract -- <folder> [--out review.json] [--model qwen3-vl:8b]
+ *                            [--host http://localhost:11434]
+ *
+ * Reads every image in <folder>, runs each through the local vision model, and
+ * writes a review file (default <folder>/scan-review.json). Review/edit that
+ * file, then feed it to `npm run scan:import`.
+ */
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { DEFAULT_OLLAMA, extractReceipt } from "./ollama.ts";
+import { isScannable, type ReviewEntry, type ReviewFile } from "./review.ts";
+
+type Args = {
+  folder: string;
+  out: string;
+  model: string;
+  host: string;
+};
+
+function parseArgs(argv: string[]): Args {
+  const positional: string[] = [];
+  let out: string | undefined;
+  let model = DEFAULT_OLLAMA.model;
+  let host = DEFAULT_OLLAMA.host;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--out") out = argv[++i];
+    else if (arg === "--model") model = argv[++i] ?? model;
+    else if (arg === "--host") host = argv[++i] ?? host;
+    else if (arg?.startsWith("--")) throw new Error(`Unknown flag: ${arg}`);
+    else if (arg) positional.push(arg);
+  }
+
+  const folder = positional[0];
+  if (!folder) {
+    throw new Error(
+      "Usage: scan:extract -- <folder> [--out file] [--model m] [--host url]",
+    );
+  }
+  return {
+    folder: resolve(folder),
+    out: out ? resolve(out) : join(resolve(folder), "scan-review.json"),
+    model,
+    host,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const all = await readdir(args.folder);
+  const images = all.filter(isScannable).sort();
+  if (images.length === 0) {
+    console.error(`No scannable images in ${args.folder}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `[scan] ${images.length} image(s) in ${args.folder} → ${args.model}`,
+  );
+
+  const entries: ReviewEntry[] = [];
+  for (const file of images) {
+    process.stdout.write(`  • ${file} … `);
+    try {
+      const bytes = await readFile(join(args.folder, file));
+      const extracted = await extractReceipt(new Uint8Array(bytes), {
+        host: args.host,
+        model: args.model,
+      });
+      entries.push({ file, status: "pending", extracted });
+      const cost =
+        extracted.totalCost != null ? `$${extracted.totalCost}` : "?";
+      console.log(`ok — "${extracted.suggestedTitle}" (${cost})`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      entries.push({ file, status: "skip", error: message, extracted: null });
+      console.log(`FAILED — ${message}`);
+    }
+  }
+
+  const review: ReviewFile = {
+    version: 1,
+    createdAt: new Date().toISOString(),
+    sourceDir: args.folder,
+    model: args.model,
+    entries,
+  };
+  await writeFile(args.out, `${JSON.stringify(review, null, 2)}\n`);
+
+  const ok = entries.filter((e) => e.status === "pending").length;
+  console.log(
+    `\n[scan] wrote ${args.out} — ${ok}/${entries.length} extracted.\n` +
+      `Review it, then: npm run scan:import -- ${args.out} --vehicle <id>`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
Digitize a backlog of paper shop invoices for **$0** by running a vision model locally (Ollama `qwen3-vl:8b`) instead of a paid API — the receipts never leave the machine. This ships **Phase 1** (the batch CLI), the #1 priority in CLAUDE.md's "Next up".

## Flow

Two steps with a human review in the middle:

```sh
npm run scan:extract -- <folder>                                  # scans → scan-review.json
npm run scan:import  -- <review.json> --vehicle <id> [--reminders] # → logs + attachments + reminders
```

Each invoice becomes a work log (title, cost, odometer, service date, line items in notes) with the **original scan stored as an attachment**. `--reminders` drafts a follow-up reminder from the tech's recommended-work note.

## What's included

- **`log_attachments` table** + migration `0003`; `attachment.server.ts` model — uploads via the storage layer (LocalFS / R2), access checked against the log's vehicle
- **`app/scan/receipt.ts`** — isomorphic extraction contract (JSON schema + prompt + trust-nothing `normalizeReceipt`/`receiptToNotes`), shared so the planned in-app **Workers AI** path (Phase 2) extracts identically
- **`scripts/scan-bay/`** — Ollama client + `scan`/`import` commands. Import is idempotent (entries stamped with their logId) and defaults the acting user to the vehicle owner (`--user` to override). All writes go through the model layer, so crew-access checks apply.
- Log detail page renders attached scans
- Tests for the normalizer (coercion/edge cases) and the attachment model (incl. access-control)
- Docs: `.env.example` (`OLLAMA_HOST`/`SCAN_MODEL`), CLAUDE.md, README

Deliberately **not** the Anthropic API — cost.

## Verification

- **Real end-to-end run** against local Postgres + Ollama: extracted a test invoice ($213, 84,612 mi, 5 line items, recommended-work note) → created log + stored file + reminder → confirmed idempotent re-run. Test artifacts cleaned up.
- `npm run typecheck` ✓ · `npm run lint` ✓ · **28/28 tests pass** (10 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)