### PR TITLE
feat: rebrand Crew Chief → Logbook

### DIFF
--- a/.claude/commands/build-next.md
+++ b/.claude/commands/build-next.md
@@ -1,4 +1,4 @@
-You are a Wrench (builder agent) on the Crew Chief Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
+You are a Wrench (builder agent) on the Logbook Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
 
 Read `SERVICE_WRITER.md` for the full Wrench protocol (task selection algorithm, concurrency protocol, and rules). Read `CLAUDE.md`, `AGENTS.md`, and `AGENT.md` for code conventions and safety rules. Then follow this workflow:
 

--- a/.claude/commands/groom-issues.md
+++ b/.claude/commands/groom-issues.md
@@ -1,4 +1,4 @@
-You are the Crew Chief Service Writer. Your job is to groom GitHub Issues — triage new ones, build out specs, ask clarifying questions, reject out-of-scope requests, and revisit existing priorities.
+You are the Logbook Service Writer. Your job is to groom GitHub Issues — triage new ones, build out specs, ask clarifying questions, reject out-of-scope requests, and revisit existing priorities.
 
 Read `SERVICE_WRITER.md` for your full personality, decision framework, gatekeeping rules, security review guidelines, and grooming protocol. Then follow this workflow:
 
@@ -31,7 +31,7 @@ gh issue view <number>
 Then apply the grooming protocol from SERVICE_WRITER.md:
 
 ### a) Scope check
-- Does this issue relate to Crew Chief's purpose (tracking work/maintenance on vehicles, users, mechanics, parts, reporting)?
+- Does this issue relate to Logbook's purpose (tracking work/maintenance on vehicles, users, mechanics, parts, reporting)?
 - If **out of scope**: Leave a polite comment explaining why, add the `wontfix` label, and close the issue.
 
 ### b) Security check

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: "\U0001F4A1 Feature Request"
-description: Suggest a new feature or improvement for Crew Chief
+description: Suggest a new feature or improvement for Logbook
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/workflows/build-next.yml
+++ b/.github/workflows/build-next.yml
@@ -37,7 +37,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "github-actions[bot]"
           prompt: |
-            You are a Wrench (builder agent) on the Crew Chief Pit Lane crew. You've been asked to implement issue #${{ inputs.issue_number }}.
+            You are a Wrench (builder agent) on the Logbook Pit Lane crew. You've been asked to implement issue #${{ inputs.issue_number }}.
 
             Read `SERVICE_WRITER.md` for the full Wrench protocol. Read `CLAUDE.md`, `AGENTS.md`, and `AGENT.md` for code conventions and safety rules. Then follow this workflow:
 
@@ -136,7 +136,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "github-actions[bot]"
           prompt: |
-            You are a Wrench (builder agent) on the Crew Chief Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
+            You are a Wrench (builder agent) on the Logbook Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
 
             Read `SERVICE_WRITER.md` for the full Wrench protocol. Read `CLAUDE.md`, `AGENTS.md`, and `AGENT.md` for code conventions and safety rules. Then follow this workflow:
 

--- a/.github/workflows/groom-issues.yml
+++ b/.github/workflows/groom-issues.yml
@@ -32,7 +32,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: "true"
           prompt: |
-            You are the Crew Chief Service Writer. Groom issue #${{ github.event.issue.number }}.
+            You are the Logbook Service Writer. Groom issue #${{ github.event.issue.number }}.
 
             Start by reading these files (use a single bash command: `cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`), then read the issue with `gh issue view ${{ github.event.issue.number }} -R ${{ github.repository }}`.
 
@@ -47,7 +47,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the Crew Chief Service Writer. Groom issue #${{ inputs.issue_number }}.
+            You are the Logbook Service Writer. Groom issue #${{ inputs.issue_number }}.
 
             Start by reading these files (use a single bash command: `cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`), then read the issue with `gh issue view ${{ inputs.issue_number }} -R ${{ github.repository }}`.
 
@@ -62,7 +62,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the Crew Chief Service Writer. Groom all ungroomed issues.
+            You are the Logbook Service Writer. Groom all ungroomed issues.
 
             Start by reading these files (use a single bash command: `cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`).
 
@@ -95,7 +95,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the Crew Chief Service Writer. A human has responded to clarification questions on issue #${{ github.event.issue.number }}.
+            You are the Logbook Service Writer. A human has responded to clarification questions on issue #${{ github.event.issue.number }}.
 
             Start by reading context files (`cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`) and the full issue with comments (`gh issue view ${{ github.event.issue.number }} -R ${{ github.repository }} --comments`).
 
@@ -128,7 +128,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the Crew Chief Service Writer. A `/groom` command was issued on issue #${{ github.event.issue.number }}. This is a (re-)groom — start fresh.
+            You are the Logbook Service Writer. A `/groom` command was issued on issue #${{ github.event.issue.number }}. This is a (re-)groom — start fresh.
 
             First, strip stale status labels in one command:
             ```bash

--- a/.github/workflows/test-driver.yml
+++ b/.github/workflows/test-driver.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the **Test Driver** on the Crew Chief Pit Crew. Read `TEST_DRIVER.md` for your full protocol. Also read `AGENTS.md` for project context.
+            You are the **Test Driver** on the Logbook Pit Crew. Read `TEST_DRIVER.md` for your full protocol. Also read `AGENTS.md` for project context.
 
             ## Your task
 

--- a/CHIEF_MECHANIC.md
+++ b/CHIEF_MECHANIC.md
@@ -7,7 +7,7 @@
 > gets rebuilt vs. replaced.
 
 Read `AGENT.md` for full project context. This file defines the Chief
-Mechanic's persona for evaluating and evolving the Crew Chief system.
+Mechanic's persona for evaluating and evolving the Logbook system.
 
 ## Identity
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Crew Chief
+# CLAUDE.md — Logbook
 
 Quick reference for Claude Code sessions in this repo. Read `README.md` for
 user-facing context and tool-choice rationale.
@@ -211,9 +211,9 @@ including a backlog of paper shop invoices.
   photo still attaches on save.
 - Deliberately NOT the Anthropic API — cost. Don't suggest it for this.
 
-### 2. Crew Chief MCP server
+### 2. Logbook MCP server
 
-So the crew can talk to Crew Chief from their own Claude accounts
+So the crew can talk to Logbook from their own Claude accounts
 (claude.ai custom connector, works on mobile). NOTE: rally-specific
 features stay OUT of the app — the app is generic vehicle maintenance;
 rally procedure lives in Scott's external rebelle-rally skill, which will

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Self-host image: app + Postgres 16 + s6-overlay, one mounted /app/data volume.
 # Run with:
-#   docker run -d -p 3000:3000 -v crew-chief-data:/app/data \
-#     -e SESSION_SECRET=... ghcr.io/scottprue/crew-chief:latest
+#   docker run -d -p 3000:3000 -v logbook-data:/app/data \
+#     -e SESSION_SECRET=... ghcr.io/scottprue/logbook:latest
 
 ARG NODE_VERSION=24
 ARG S6_OVERLAY_VERSION=3.2.0.2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Crew Chief
+# Logbook
 
 A personal maintenance log for every car you own. Track services, parts,
 odometer, cost, and notes per vehicle. Export your whole history as JSON
@@ -129,9 +129,9 @@ single container. One command, one mounted volume:
 ```sh
 docker run -d \
   -p 3000:3000 \
-  -v crew-chief-data:/app/data \
+  -v logbook-data:/app/data \
   -e SESSION_SECRET="$(openssl rand -base64 48)" \
-  ghcr.io/scottprue/crew-chief:latest
+  ghcr.io/scottprue/logbook:latest
 ```
 
 Everything persistent (Postgres cluster + uploaded files) lives under
@@ -331,7 +331,7 @@ breaking old bundles.
 
 ## Scan Bay — digitizing paper records
 
-A big part of Crew Chief is getting a backlog of paper shop invoices into the
+A big part of Logbook is getting a backlog of paper shop invoices into the
 app. Scan Bay does that locally, for **$0** — it runs a vision model on your own
 machine (Ollama + `qwen3-vl:8b` by default), so the receipts never leave your
 laptop and there's no per-page API cost.

--- a/SERVICE_WRITER.md
+++ b/SERVICE_WRITER.md
@@ -7,7 +7,7 @@
 
 ## Identity
 
-You are the **Service Writer** for Crew Chief — the PM agent on the
+You are the **Service Writer** for Logbook — the PM agent on the
 **Pit Lane** crew. You operate with memory across sessions, maintaining a
 living roadmap and making prioritization decisions grounded in user
 feedback, usage data, and the project's goal: a reliable, pleasant web app
@@ -75,7 +75,7 @@ When prioritizing, weight these factors:
 ### Gatekeeping & Scope Enforcement
 
 You are the **first line of defense** for the backlog. Not every request
-belongs in Crew Chief's roadmap. Your job is to say **no** when
+belongs in Logbook's roadmap. Your job is to say **no** when
 appropriate.
 
 **Accept** issues that:
@@ -130,7 +130,7 @@ follow this process for **each issue**:
 #### For new issues (no priority label yet):
 
 1. **Read** the full issue body and any existing comments
-2. **Validate scope** — Does this belong in Crew Chief? If not, reject
+2. **Validate scope** — Does this belong in Logbook? If not, reject
    per gatekeeping rules above
 3. **Security check** — Does anything look suspicious or unsafe? If so, flag
    per security rules above
@@ -191,7 +191,7 @@ follow this process for **each issue**:
 
 ## Context
 
-### What Crew Chief Does Today
+### What Logbook Does Today
 
 - **Users** — register (`/join`), login (`/login`), logout (`/logout`). Cookie
   sessions via `createCookieSessionStorage`.

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -18,7 +18,7 @@ export const Route = createRootRoute({
         name: "viewport",
         content: "width=device-width, initial-scale=1, viewport-fit=cover",
       },
-      { title: "Crew Chief" },
+      { title: "Logbook" },
       { name: "theme-color", content: "#0c0e11" },
     ],
     links: [{ rel: "stylesheet", href: stylesHref }],

--- a/app/routes/_authed.tsx
+++ b/app/routes/_authed.tsx
@@ -76,7 +76,7 @@ function AuthedLayout() {
             >
               🏁
             </span>
-            <span>Crew Chief</span>
+            <span>Logbook</span>
           </Link>
           <div className="flex items-center gap-2">
             <GarageModeToggle />

--- a/app/routes/account.export.tsx
+++ b/app/routes/account.export.tsx
@@ -100,7 +100,7 @@ export const Route = createFileRoute("/account/export")({
 
         return Response.json(body, {
           headers: {
-            "content-disposition": `attachment; filename="crew-chief-${user.email}.json"`,
+            "content-disposition": `attachment; filename="logbook-${user.email}.json"`,
           },
         });
       },

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -8,7 +8,7 @@ function Home() {
   return (
     <main className="flex min-h-screen items-center justify-center bg-slate-50 p-8">
       <div className="w-full max-w-xl rounded-2xl bg-white p-8 shadow-sm">
-        <h1 className="text-3xl font-semibold text-slate-900">Crew Chief</h1>
+        <h1 className="text-3xl font-semibold text-slate-900">Logbook</h1>
         <p className="mt-2 text-slate-600">
           Keep a maintenance record for every car you own.
         </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "crew-chief",
+  "name": "logbook",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "crew-chief",
+      "name": "logbook",
       "dependencies": {
         "@paralleldrive/cuid2": "^3.0.0",
         "@tanstack/react-router": "1.168.23",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "crew-chief",
+  "name": "logbook",
   "private": true,
   "type": "module",
   "engines": {
@@ -26,7 +26,7 @@
     "scan:extract": "node --import tsx scripts/scan-bay/scan.ts",
     "scan:import": "node --env-file=.env --import tsx scripts/scan-bay/import.ts",
     "docker:dev": "docker compose up -d",
-    "docker:build": "docker build -t crew-chief:local .",
+    "docker:build": "docker build -t logbook:local .",
     "validate": "npm run typecheck && npm run lint && npm run test -- --run"
   },
   "dependencies": {


### PR DESCRIPTION
Renames the product to **Logbook** — the literal term for a vehicle's structured service record, instantly recognizable to anyone storing maintenance history (the goal of making this shareable beyond car people).

## What's renamed

- **App UI**: landing page, document title, app header, export filename (`logbook-<email>.json`)
- **Package metadata**: `package.json` / lockfile name, `docker:build` tag
- **Docker**: image/volume names in Dockerfile + README (`ghcr.io/scottprue/logbook`)
- **Docs**: README title/copy, CLAUDE.md (header, MCP-server section)
- **Agent layer**: product references in `.claude/commands/*`, `.github/workflows/*`, issue template, and persona docs

## Deliberately kept

- **Persona names** — Service Writer, Wrench, Test Driver, Chief Mechanic, and the **Crew Chief DevOps agent** keep their names; the racing metaphor lives on in the Pit Lane automation, where it no longer collides with the product name.
- **Crew sharing** — your crew is still your crew.

## Not in this PR (separate, deploy-affecting)

- GitHub repo slug rename (`crew-chief` → `logbook`) — old URLs redirect, but it's a remote-identity change
- Cloudflare worker name (`wrangler.jsonc` still says `vehicle-work-log`, predating even Crew Chief) — renaming the worker changes the deployed service identity

`npm run validate` ✓ (38/38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)