### PR TITLE
fix: auto-accept the Meta license gate on first Workers AI scan

### DIFF
--- a/app/scan/extract.server.test.ts
+++ b/app/scan/extract.server.test.ts
@@ -2,8 +2,29 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   extractReceiptScan,
+  isLicenseAgreementError,
   parseWorkersAiResponse,
 } from "~/scan/extract.server";
+
+describe("isLicenseAgreementError", () => {
+  it("matches the Workers AI 5016 license-gate error", () => {
+    // Verbatim shape seen in production (typo included).
+    expect(
+      isLicenseAgreementError(
+        new Error(
+          "5016: Prior to using this model you must sumbit the prompt " +
+            "'agree'. By submitting 'agree', you hereby agree to the " +
+            "llama-3.2-11b-vision-instruction Community License",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(isLicenseAgreementError(new Error("3036: capacity"))).toBe(false);
+    expect(isLicenseAgreementError(new Error("network timeout"))).toBe(false);
+  });
+});
 
 describe("parseWorkersAiResponse", () => {
   it("passes through an already-parsed response object", () => {

--- a/app/scan/extract.server.ts
+++ b/app/scan/extract.server.ts
@@ -84,6 +84,35 @@ export function parseWorkersAiResponse(result: unknown): unknown {
  * when no extraction backend is reachable — the scan page surfaces it and
  * lets the user fill the log in manually (the photo still gets attached).
  */
+/**
+ * Workers AI error 5016: Meta-licensed models require a one-time, per-account
+ * license acceptance — submitting the literal prompt "agree" to the model.
+ * Exported for tests.
+ */
+export function isLicenseAgreementError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /\b5016\b|prompt 'agree'|submit(?:ting)? 'agree'/i.test(message);
+}
+
+async function runWorkersAiExtraction(
+  workersAi: { ai: WorkersAi; model: string },
+  image: Uint8Array,
+): Promise<ExtractedReceipt> {
+  // The model's input schema takes the image as an array of 8-bit ints
+  // alongside a plain prompt; JSON mode rides on response_format.
+  const result = await workersAi.ai.run(workersAi.model, {
+    prompt: EXTRACTION_PROMPT,
+    image: Array.from(image),
+    response_format: {
+      type: "json_schema",
+      json_schema: RECEIPT_JSON_SCHEMA,
+    },
+    temperature: 0,
+    max_tokens: 1024,
+  });
+  return normalizeReceipt(parseWorkersAiResponse(result));
+}
+
 export async function extractReceiptScan(
   image: Uint8Array,
 ): Promise<ExtractedReceipt> {
@@ -92,24 +121,24 @@ export async function extractReceiptScan(
 
   if (workersAi) {
     try {
-      // The model's input schema takes the image as an array of 8-bit ints
-      // alongside a plain prompt; JSON mode rides on response_format.
-      const result = await workersAi.ai.run(workersAi.model, {
-        prompt: EXTRACTION_PROMPT,
-        image: Array.from(image),
-        response_format: {
-          type: "json_schema",
-          json_schema: RECEIPT_JSON_SCHEMA,
-        },
-        temperature: 0,
-        max_tokens: 1024,
-      });
-      return normalizeReceipt(parseWorkersAiResponse(result));
+      return await runWorkersAiExtraction(workersAi, image);
     } catch (err) {
-      // Don't give up yet — in dev the binding exists but remote bindings
-      // may be off (CF_REMOTE_BINDINGS unset), and a local Ollama may be
-      // running. On production Workers the Ollama attempt fails fast.
-      workersAiError = err instanceof Error ? err : new Error(String(err));
+      if (isLicenseAgreementError(err)) {
+        // First-ever call on this Cloudflare account: accept the Meta
+        // license (one-time, per account) and retry the extraction.
+        try {
+          await workersAi.ai.run(workersAi.model, { prompt: "agree" });
+          return await runWorkersAiExtraction(workersAi, image);
+        } catch (retryErr) {
+          workersAiError =
+            retryErr instanceof Error ? retryErr : new Error(String(retryErr));
+        }
+      } else {
+        // Don't give up yet — in dev the binding exists but remote bindings
+        // may be off (CF_REMOTE_BINDINGS unset), and a local Ollama may be
+        // running. On production Workers the Ollama attempt fails fast.
+        workersAiError = err instanceof Error ? err : new Error(String(err));
+      }
     }
   }
 


### PR DESCRIPTION
First real scan on production failed with:

> `5016: Prior to using this model you must sumbit the prompt 'agree'…`

Workers AI's Meta-licensed models (including our default `@cf/meta/llama-3.2-11b-vision-instruct`) require a **one-time, per-account** license acceptance: send the literal prompt `agree` to the model. This is documented behavior, not a bug in the input shape — and notably the rest of the pipeline behaved correctly (error surfaced in the UI banner, Ollama fallback attempted, photo still attachable).

## Fix

`extractReceiptScan()` now detects the 5016 license-gate error, submits `agree` via the binding, and retries the extraction once. Self-heals for our account and for any self-hoster pointing the binding at a fresh Cloudflare account — no manual dashboard step needed.

- `isLicenseAgreementError()` matched against the verbatim production error text (Cloudflare's typo included) in tests
- `npm run validate` ✓ — 44/44 tests (2 new)

After deploy, retry the receipt scan — the first attempt performs the acceptance automatically. (Alternatively the acceptance can be done right now by sending `agree` to the model in the dashboard's Workers AI playground; the code fix makes that unnecessary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)