### PR TITLE
fix: pass the scan image as an image_url content part (verified live)

### DIFF
--- a/app/routes/_authed.vehicles.$vehicleId.scan.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.scan.tsx
@@ -54,7 +54,7 @@ const extractScanFn = createServerFn({ method: "POST" })
 
     try {
       const bytes = new Uint8Array(await checked.file.arrayBuffer());
-      const receipt = await extractReceiptScan(bytes);
+      const receipt = await extractReceiptScan(bytes, checked.file.type);
       return { receipt };
     } catch (err) {
       return {

--- a/app/scan/extract.server.test.ts
+++ b/app/scan/extract.server.test.ts
@@ -2,8 +2,29 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   extractReceiptScan,
+  isLicenseAgreementError,
   parseWorkersAiResponse,
 } from "~/scan/extract.server";
+
+describe("isLicenseAgreementError", () => {
+  it("matches the Workers AI 5016 license-gate error", () => {
+    // Verbatim shape seen in production (typo included).
+    expect(
+      isLicenseAgreementError(
+        new Error(
+          "5016: Prior to using this model you must sumbit the prompt " +
+            "'agree'. By submitting 'agree', you hereby agree to the " +
+            "llama-3.2-11b-vision-instruction Community License",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(isLicenseAgreementError(new Error("3036: capacity"))).toBe(false);
+    expect(isLicenseAgreementError(new Error("network timeout"))).toBe(false);
+  });
+});
 
 describe("parseWorkersAiResponse", () => {
   it("passes through an already-parsed response object", () => {

--- a/app/scan/extract.server.test.ts
+++ b/app/scan/extract.server.test.ts
@@ -54,6 +54,23 @@ describe("parseWorkersAiResponse", () => {
     ).toEqual({ odometer: 84612 });
   });
 
+  it("unwraps a nested response.content string", () => {
+    expect(
+      parseWorkersAiResponse({
+        response: { content: '{"suggestedTitle":"Coolant flush"}' },
+      }),
+    ).toEqual({ suggestedTitle: "Coolant flush" });
+  });
+
+  it("digs JSON out of prose wrapping", () => {
+    expect(
+      parseWorkersAiResponse({
+        response:
+          'Here is the extracted data:\n{"totalCost":213,"odometer":84612}\nLet me know if you need anything else!',
+      }),
+    ).toEqual({ totalCost: 213, odometer: 84612 });
+  });
+
   it("throws on empty or junk responses", () => {
     expect(() => parseWorkersAiResponse({})).toThrow("empty response");
     expect(() => parseWorkersAiResponse({ response: "not json" })).toThrow(

--- a/app/scan/extract.server.ts
+++ b/app/scan/extract.server.ts
@@ -8,6 +8,8 @@
  * batch-scanned invoice extract identically.
  */
 
+import { Buffer } from "node:buffer";
+
 import { extractReceipt as extractWithOllama } from "~/scan/ollama.server";
 import {
   EXTRACTION_PROMPT,
@@ -109,28 +111,37 @@ export function isLicenseAgreementError(err: unknown): boolean {
 async function runWorkersAiExtraction(
   workersAi: { ai: WorkersAi; model: string },
   image: Uint8Array,
+  contentType: string,
 ): Promise<ExtractedReceipt> {
-  // JSON mode (`response_format`) is only honored on the chat/messages
-  // input form — with a bare `prompt` the request routes to the
-  // image-to-text task and the schema is ignored, yielding prose. The
-  // image itself still rides at the top level as an array of 8-bit ints.
+  // Input shape verified against the live model (2026-06): the image must be
+  // an `image_url` data-URL part *inside* the user message. A top-level
+  // `image` next to `messages` is rejected (error 3030), and a bare `prompt`
+  // routes to the image-to-text task. response_format is honored on this
+  // chat form. The JSON nudge is belt-and-braces for runs where it isn't;
+  // Ollama enforces the schema natively so it stays out of the shared
+  // EXTRACTION_PROMPT.
+  const dataUrl = `data:${contentType};base64,${Buffer.from(image).toString("base64")}`;
   const result = await workersAi.ai.run(workersAi.model, {
-    // The JSON nudge is belt-and-braces for runs where response_format is
-    // ignored; Ollama enforces the schema natively so it stays out of the
-    // shared EXTRACTION_PROMPT.
     messages: [
       {
         role: "user",
-        content: `${EXTRACTION_PROMPT} Respond with only a JSON object — no prose.`,
+        content: [
+          {
+            type: "text",
+            text: `${EXTRACTION_PROMPT} Respond with only a JSON object — no prose.`,
+          },
+          { type: "image_url", image_url: { url: dataUrl } },
+        ],
       },
     ],
-    image: Array.from(image),
     response_format: {
       type: "json_schema",
       json_schema: RECEIPT_JSON_SCHEMA,
     },
     temperature: 0,
-    max_tokens: 1024,
+    // Generous headroom — a long line-itemed invoice that gets truncated
+    // mid-JSON reads as "did not return valid JSON" to the parser.
+    max_tokens: 2048,
   });
   return normalizeReceipt(parseWorkersAiResponse(result));
 }
@@ -142,20 +153,21 @@ async function runWorkersAiExtraction(
  */
 export async function extractReceiptScan(
   image: Uint8Array,
+  contentType = "image/jpeg",
 ): Promise<ExtractedReceipt> {
   const workersAi = await getWorkersAi();
   let workersAiError: Error | null = null;
 
   if (workersAi) {
     try {
-      return await runWorkersAiExtraction(workersAi, image);
+      return await runWorkersAiExtraction(workersAi, image, contentType);
     } catch (err) {
       if (isLicenseAgreementError(err)) {
         // First-ever call on this Cloudflare account: accept the Meta
         // license (one-time, per account) and retry the extraction.
         try {
           await workersAi.ai.run(workersAi.model, { prompt: "agree" });
-          return await runWorkersAiExtraction(workersAi, image);
+          return await runWorkersAiExtraction(workersAi, image, contentType);
         } catch (retryErr) {
           workersAiError =
             retryErr instanceof Error ? retryErr : new Error(String(retryErr));

--- a/app/scan/extract.server.ts
+++ b/app/scan/extract.server.ts
@@ -84,6 +84,35 @@ export function parseWorkersAiResponse(result: unknown): unknown {
  * when no extraction backend is reachable — the scan page surfaces it and
  * lets the user fill the log in manually (the photo still gets attached).
  */
+/**
+ * Workers AI error 5016: Meta-licensed models require a one-time, per-account
+ * license acceptance — submitting the literal prompt "agree" to the model.
+ * Exported for tests.
+ */
+export function isLicenseAgreementError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /\b5016\b|prompt 'agree'|submit(?:ting)? 'agree'/i.test(message);
+}
+
+async function runWorkersAiExtraction(
+  workersAi: { ai: WorkersAi; model: string },
+  image: Uint8Array,
+): Promise<ExtractedReceipt> {
+  // The model's input schema takes the image as an array of 8-bit ints
+  // alongside a plain prompt; JSON mode rides on response_format.
+  const result = await workersAi.ai.run(workersAi.model, {
+    prompt: EXTRACTION_PROMPT,
+    image: Array.from(image),
+    response_format: {
+      type: "json_schema",
+      json_schema: RECEIPT_JSON_SCHEMA,
+    },
+    temperature: 0,
+    max_tokens: 1024,
+  });
+  return normalizeReceipt(parseWorkersAiResponse(result));
+}
+
 export async function extractReceiptScan(
   image: Uint8Array,
 ): Promise<ExtractedReceipt> {
@@ -92,24 +121,24 @@ export async function extractReceiptScan(
 
   if (workersAi) {
     try {
-      // The model's input schema takes the image as an array of 8-bit ints
-      // alongside a plain prompt; JSON mode rides on response_format.
-      const result = await workersAi.ai.run(workersAi.model, {
-        prompt: EXTRACTION_PROMPT,
-        image: Array.from(image),
-        response_format: {
-          type: "json_schema",
-          json_schema: RECEIPT_JSON_SCHEMA,
-        },
-        temperature: 0,
-        max_tokens: 1024,
-      });
-      return normalizeReceipt(parseWorkersAiResponse(result));
+      return await runWorkersAiExtraction(workersAi, image);
     } catch (err) {
-      // Don't give up yet — in dev the binding exists but remote bindings
-      // may be off (CF_REMOTE_BINDINGS unset), and a local Ollama may be
-      // running. On production Workers the Ollama attempt fails fast.
-      workersAiError = err instanceof Error ? err : new Error(String(err));
+      if (isLicenseAgreementError(err)) {
+        // First-ever call on this Cloudflare account: accept the Meta
+        // license (one-time, per account) and retry the extraction.
+        try {
+          await workersAi.ai.run(workersAi.model, { prompt: "agree" });
+          return await runWorkersAiExtraction(workersAi, image);
+        } catch (retryErr) {
+          workersAiError =
+            retryErr instanceof Error ? retryErr : new Error(String(retryErr));
+        }
+      } else {
+        // Don't give up yet — in dev the binding exists but remote bindings
+        // may be off (CF_REMOTE_BINDINGS unset), and a local Ollama may be
+        // running. On production Workers the Ollama attempt fails fast.
+        workersAiError = err instanceof Error ? err : new Error(String(err));
+      }
     }
   }
 

--- a/app/scan/extract.server.ts
+++ b/app/scan/extract.server.ts
@@ -64,13 +64,30 @@ export function parseWorkersAiResponse(result: unknown): unknown {
     payload = first?.message?.content;
   }
 
-  if (payload != null && typeof payload === "object") return payload;
+  if (payload != null && typeof payload === "object") {
+    // Some response shapes nest the actual text one level deeper
+    // (e.g. `{ response: { content: "…" } }`). Unwrap before giving up.
+    const inner = (payload as Record<string, unknown>).content;
+    if (typeof inner === "string") payload = inner;
+    else return payload;
+  }
   if (typeof payload === "string") {
     // Tolerate markdown fencing around the JSON body.
     const text = payload.replace(/^\s*```(?:json)?\s*|\s*```\s*$/g, "");
     try {
       return JSON.parse(text);
     } catch {
+      // The model wrapped JSON in prose ("Here is the extracted data: {…}").
+      // Take the outermost brace span and try that before failing.
+      const start = text.indexOf("{");
+      const end = text.lastIndexOf("}");
+      if (start !== -1 && end > start) {
+        try {
+          return JSON.parse(text.slice(start, end + 1));
+        } catch {
+          // fall through to the descriptive error below
+        }
+      }
       throw new Error(
         `Workers AI did not return valid JSON: ${text.slice(0, 200)}`,
       );
@@ -79,11 +96,6 @@ export function parseWorkersAiResponse(result: unknown): unknown {
   throw new Error("Workers AI returned an empty response");
 }
 
-/**
- * Extract a receipt from one image. Throws with a human-readable message
- * when no extraction backend is reachable — the scan page surfaces it and
- * lets the user fill the log in manually (the photo still gets attached).
- */
 /**
  * Workers AI error 5016: Meta-licensed models require a one-time, per-account
  * license acceptance — submitting the literal prompt "agree" to the model.
@@ -98,10 +110,20 @@ async function runWorkersAiExtraction(
   workersAi: { ai: WorkersAi; model: string },
   image: Uint8Array,
 ): Promise<ExtractedReceipt> {
-  // The model's input schema takes the image as an array of 8-bit ints
-  // alongside a plain prompt; JSON mode rides on response_format.
+  // JSON mode (`response_format`) is only honored on the chat/messages
+  // input form — with a bare `prompt` the request routes to the
+  // image-to-text task and the schema is ignored, yielding prose. The
+  // image itself still rides at the top level as an array of 8-bit ints.
   const result = await workersAi.ai.run(workersAi.model, {
-    prompt: EXTRACTION_PROMPT,
+    // The JSON nudge is belt-and-braces for runs where response_format is
+    // ignored; Ollama enforces the schema natively so it stays out of the
+    // shared EXTRACTION_PROMPT.
+    messages: [
+      {
+        role: "user",
+        content: `${EXTRACTION_PROMPT} Respond with only a JSON object — no prose.`,
+      },
+    ],
     image: Array.from(image),
     response_format: {
       type: "json_schema",
@@ -113,6 +135,11 @@ async function runWorkersAiExtraction(
   return normalizeReceipt(parseWorkersAiResponse(result));
 }
 
+/**
+ * Extract a receipt from one image. Throws with a human-readable message
+ * when no extraction backend is reachable — the scan page surfaces it and
+ * lets the user fill the log in manually (the photo still gets attached).
+ */
 export async function extractReceiptScan(
   image: Uint8Array,
 ): Promise<ExtractedReceipt> {
@@ -140,6 +167,18 @@ export async function extractReceiptScan(
         workersAiError = err instanceof Error ? err : new Error(String(err));
       }
     }
+  }
+
+  // The Ollama fallback only makes sense where localhost can exist: Node
+  // self-host (no binding) and local dev (binding present, remote bindings
+  // off). On deployed Workers a localhost fetch just bounces off Cloudflare
+  // (403, error 1003) and buries the real error, so fail with the Workers
+  // AI message directly.
+  const isDev = (import.meta as { env?: { DEV?: boolean } }).env?.DEV === true;
+  if (workersAiError && !isDev) {
+    throw new Error(
+      `Receipt extraction failed (Workers AI: ${workersAiError.message})`,
+    );
   }
 
   try {

--- a/app/scan/extract.server.ts
+++ b/app/scan/extract.server.ts
@@ -140,35 +140,6 @@ async function runWorkersAiExtraction(
  * when no extraction backend is reachable — the scan page surfaces it and
  * lets the user fill the log in manually (the photo still gets attached).
  */
-/**
- * Workers AI error 5016: Meta-licensed models require a one-time, per-account
- * license acceptance — submitting the literal prompt "agree" to the model.
- * Exported for tests.
- */
-export function isLicenseAgreementError(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return /\b5016\b|prompt 'agree'|submit(?:ting)? 'agree'/i.test(message);
-}
-
-async function runWorkersAiExtraction(
-  workersAi: { ai: WorkersAi; model: string },
-  image: Uint8Array,
-): Promise<ExtractedReceipt> {
-  // The model's input schema takes the image as an array of 8-bit ints
-  // alongside a plain prompt; JSON mode rides on response_format.
-  const result = await workersAi.ai.run(workersAi.model, {
-    prompt: EXTRACTION_PROMPT,
-    image: Array.from(image),
-    response_format: {
-      type: "json_schema",
-      json_schema: RECEIPT_JSON_SCHEMA,
-    },
-    temperature: 0,
-    max_tokens: 1024,
-  });
-  return normalizeReceipt(parseWorkersAiResponse(result));
-}
-
 export async function extractReceiptScan(
   image: Uint8Array,
 ): Promise<ExtractedReceipt> {


### PR DESCRIPTION
Ends the input-shape guessing: this time the shape was **verified against the live model** before shipping. A scratch worker fired five candidate input shapes at `@cf/meta/llama-3.2-11b-vision-instruct` with the real binding:

| Shape | Result |
| --- | --- |
| `messages` + top-level `image` (what prod runs → #47) | ❌ `3030: Unable to add image…` (the production error) |
| `prompt` + top-level `image` (original #41 shape) | ✅ schema JSON |
| content part `type: "image"` | ❌ `8001: Invalid input` |
| **content part `image_url` (data URL)** | ✅ **schema JSON** ← shipped |
| `messages` + top-level data-URL | ❌ 3030 |

The winning form embeds the image as an `image_url` data-URL part inside the user message; `response_format` json_schema is honored there. Content type now threads through from the uploaded file. Also bumps `max_tokens` 1024 → 2048 — a long invoice truncated mid-JSON would read as "did not return valid JSON", the likely cause of the earlier prose failure on a real photo.

## Verification

- Five-shape live test as above (scratch worker, real AI binding)
- **Full scan-page flow in dev with `CF_REMOTE_BINDINGS=1` — real Workers AI, the exact production code path**: photo → extraction → form prefilled with "Front brakes + oil change", $213, 84,612 mi, 2026-05-02, recommended-work note → reminder checkbox present
- `npm run validate` ✓ — 46/46

Note: the 11B model omitted line items on the test invoice (weaker at tables than the local qwen3-vl). Extraction quality tuning on a real phone photo is a sensible follow-up; the trust-nothing normalizer already handles partial output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)