### PR TITLE
fix(scan): upgrade to llama-4-scout + structuring fallback + failure logging

### DIFF
--- a/app/scan/extract.server.ts
+++ b/app/scan/extract.server.ts
@@ -19,11 +19,13 @@ import {
 } from "~/scan/receipt";
 
 /**
- * Vision model on Workers AI that supports both image input and JSON mode.
- * Override with a `SCAN_MODEL` Workers var (wrangler.jsonc `vars` or the
- * dashboard) — no deploy needed to swap models.
+ * Vision model on Workers AI. Llama 4 Scout, verified live (2026-06): it
+ * honors json_schema on busy multi-line-item receipts where
+ * llama-3.2-11b-vision silently dropped to prose. Override with a
+ * `SCAN_MODEL` Workers var (wrangler.jsonc `vars` or the dashboard) — no
+ * deploy needed to swap models.
  */
-const DEFAULT_WORKERS_MODEL = "@cf/meta/llama-3.2-11b-vision-instruct";
+const DEFAULT_WORKERS_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 
 type WorkersAi = {
   run(model: string, input: Record<string, unknown>): Promise<unknown>;
@@ -108,6 +110,31 @@ export function isLicenseAgreementError(err: unknown): boolean {
   return /\b5016\b|prompt 'agree'|submit(?:ting)? 'agree'/i.test(message);
 }
 
+/** The raw text payload of an `env.AI.run` result, or null if not textual. */
+function workersAiResponseText(result: unknown): string | null {
+  const r = (result && typeof result === "object" ? result : {}) as Record<
+    string,
+    unknown
+  >;
+  let payload: unknown = r.response;
+  if (payload == null && Array.isArray(r.choices)) {
+    const first = r.choices[0] as
+      | { message?: { content?: unknown } }
+      | undefined;
+    payload = first?.message?.content;
+  }
+  if (payload != null && typeof payload === "object") {
+    const inner = (payload as Record<string, unknown>).content;
+    if (typeof inner === "string") payload = inner;
+  }
+  return typeof payload === "string" ? payload : null;
+}
+
+const RESPONSE_FORMAT = {
+  type: "json_schema",
+  json_schema: RECEIPT_JSON_SCHEMA,
+};
+
 async function runWorkersAiExtraction(
   workersAi: { ai: WorkersAi; model: string },
   image: Uint8Array,
@@ -134,16 +161,45 @@ async function runWorkersAiExtraction(
         ],
       },
     ],
-    response_format: {
-      type: "json_schema",
-      json_schema: RECEIPT_JSON_SCHEMA,
-    },
+    response_format: RESPONSE_FORMAT,
     temperature: 0,
     // Generous headroom — a long line-itemed invoice that gets truncated
     // mid-JSON reads as "did not return valid JSON" to the parser.
     max_tokens: 2048,
   });
-  return normalizeReceipt(parseWorkersAiResponse(result));
+
+  try {
+    return normalizeReceipt(parseWorkersAiResponse(result));
+  } catch (parseErr) {
+    // Vision models sometimes ignore response_format on busy images and
+    // answer in prose — but the prose usually contains everything we asked
+    // for. Run a text-only structuring pass, where JSON mode is reliable.
+    const prose = workersAiResponseText(result);
+    if (!prose) throw parseErr;
+    // Surfaces in `wrangler tail` / Workers Logs for diagnosis.
+    console.warn(
+      `scan: vision response was not JSON, restructuring (${prose.length} chars): ` +
+        prose.slice(0, 300),
+    );
+    const structured = await workersAi.ai.run(workersAi.model, {
+      messages: [
+        {
+          role: "user",
+          content:
+            "Below is data extracted from an auto-shop receipt. Convert it " +
+            "to a JSON object with fields: shopName, shopLocation, " +
+            "invoiceNumber, serviceDate (YYYY-MM-DD), vehicle, odometer, " +
+            "totalCost, lineItems (description/quantity/total), " +
+            "suggestedTitle, recommendedWork. Use null for anything " +
+            `missing. Respond with only the JSON object.\n\n${prose}`,
+        },
+      ],
+      response_format: RESPONSE_FORMAT,
+      temperature: 0,
+      max_tokens: 2048,
+    });
+    return normalizeReceipt(parseWorkersAiResponse(structured));
+  }
 }
 
 /**


### PR DESCRIPTION
You were right that the data was being extracted — **reproduced live**: on a busy multi-line-item invoice, `llama-3.2-11b-vision` reads everything correctly but **silently ignores `response_format`** and answers in markdown prose (`**Total Cost:** $1,224.71 …`). The extraction worked; the structuring didn't. Cloudflare documents JSON mode as best-effort, and this model's best effort degrades exactly when receipts get realistic.

## Fix — three layers, each verified against the live binding

1. **Model upgrade**: default → `@cf/meta/llama-4-scout-17b-16e-instruct`. On an 18-line-item torture invoice it returned perfect schema JSON — **18/18 line items** — where llama-3.2 returned prose with zero structure. Still overridable via the `SCAN_MODEL` var. (gemma-3 was also tested; its schema converter rejects our nullable-union types.)
2. **Structuring fallback**: if a vision pass still returns non-JSON, the prose is fed to a text-only second call (JSON mode is reliable there) before giving up.
3. **Observability**: the raw model response is now `console.warn`ed on parse failure — previously the error was caught and returned to the client with *nothing* logged, which is why there were no Cloudflare logs to pull. Future incidents show up in `wrangler tail vehicle-work-log` / Workers Logs.

## Verification

- Live harness comparison on the busy invoice: llama-3.2 → markdown prose; **scout → parsed object, all fields + 18/18 line items**
- Full scan-page flow in dev with `CF_REMOTE_BINDINGS=1` (real Workers AI, production code path): **$1224.71 · odometer 85,901 · 2026-06-08 · 18 line-item bullets in notes**, no error banner
- `npm run validate` ✓ — 46/46

Note: scout is a larger model, so it burns more free-tier neurons per scan than the 11B — a non-issue at personal scan volumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)