### PR TITLE
feat: capture the vendor from receipts, filter work history by shop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ playwright/.cache
 .idea/
 
 docs/superpowers
+# TanStack Router codegen scratch
+.tanstack/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,9 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
    (builds + parts pipeline; status vocab in `project.shared.ts` because
    client code can't import values from `.server.ts` modules),
    `attachment.server.ts` (log attachments — uploads via storage layer +
-   row insert, access checked against the log's vehicle)
+   row insert, access checked against the log's vehicle),
+   `mechanic.server.ts` (vendors/shops — case-insensitive find-or-create;
+   logs link via `logs.mechanicId`, the logs list filters by vendor)
 8. `app/scan/` — Scan Bay. `receipt.ts` is the isomorphic extraction
    contract (JSON schema + prompt + `normalizeReceipt`/`receiptToNotes`);
    `extract.server.ts` is the runtime seam (Workers AI binding on CF,

--- a/README.md
+++ b/README.md
@@ -351,8 +351,9 @@ npm run scan:import -- ~/Desktop/jeep-receipts/scan-review.json \
 
 Each imported invoice becomes a work log (title, cost, odometer, service date,
 line items in the notes) with the **original scan stored as an attachment** on
-the log. `--reminders` also drafts a follow-up reminder from any recommended
-work the tech noted ("front pads at 5mm, replace in ~5k mi").
+the log, and the shop linked as a **vendor** — the work history can be
+filtered by vendor. `--reminders` also drafts a follow-up reminder from any
+recommended work the tech noted ("front pads at 5mm, replace in ~5k mi").
 
 Notes:
 

--- a/app/models/log.server.ts
+++ b/app/models/log.server.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, sql } from "drizzle-orm";
 
 import { getDb } from "~/db/client";
 import type { Log, NewLog } from "~/db/schema";
-import { logs, users, vehicleMembers } from "~/db/schema";
+import { logs, mechanics, users, vehicleMembers } from "~/db/schema";
 import { deleteAttachmentBlobsForLogs } from "~/models/attachment.server";
 import { requireVehicleAccess } from "~/models/member.server";
 import type { Storage } from "~/storage.server";
@@ -11,6 +11,8 @@ export type { Log };
 
 export type LogListItem = Log & {
   authorName: string | null;
+  /** Vendor (mechanics table) name, when the log is linked to a shop. */
+  mechanicName: string | null;
 };
 
 /**
@@ -30,12 +32,18 @@ export async function getLog({
       authorName: sql<
         string | null
       >`coalesce(${users.displayName}, ${users.email})`,
+      mechanicName: mechanics.name,
     })
     .from(logs)
     .leftJoin(users, eq(users.id, logs.userId))
+    .leftJoin(mechanics, eq(mechanics.id, logs.mechanicId))
     .where(and(eq(logs.id, id), eq(logs.vehicleId, vehicleId)));
   if (!row) return null;
-  return { ...row.log, authorName: row.authorName };
+  return {
+    ...row.log,
+    authorName: row.authorName,
+    mechanicName: row.mechanicName,
+  };
 }
 
 export async function getLogListItems({
@@ -53,13 +61,19 @@ export async function getLogListItems({
       authorName: sql<
         string | null
       >`coalesce(${users.displayName}, ${users.email})`,
+      mechanicName: mechanics.name,
     })
     .from(logs)
     .leftJoin(users, eq(users.id, logs.userId))
+    .leftJoin(mechanics, eq(mechanics.id, logs.mechanicId))
     .where(eq(logs.vehicleId, vehicleId))
     .orderBy(desc(logs.servicedAt), desc(logs.createdAt));
   const rows = await (limit != null ? query.limit(limit) : query);
-  return rows.map((r) => ({ ...r.log, authorName: r.authorName }));
+  return rows.map((r) => ({
+    ...r.log,
+    authorName: r.authorName,
+    mechanicName: r.mechanicName,
+  }));
 }
 
 /** Highest odometer ever logged for the vehicle (best guess at current). */

--- a/app/models/mechanic.server.test.ts
+++ b/app/models/mechanic.server.test.ts
@@ -1,0 +1,68 @@
+import { eq, inArray } from "drizzle-orm";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { createDb } from "~/db/client";
+import { mechanics } from "~/db/schema";
+import { findOrCreateMechanic } from "~/models/mechanic.server";
+
+// Integration test — requires DATABASE_URL pointing at a running local
+// Postgres with migrations applied.
+
+const url = process.env.DATABASE_URL;
+if (!url) throw new Error("DATABASE_URL is required for mechanic test");
+
+const { db, close } = createDb(url);
+
+const stamp = Date.now();
+const createdIds: string[] = [];
+
+afterAll(async () => {
+  if (createdIds.length > 0) {
+    await db.delete(mechanics).where(inArray(mechanics.id, createdIds));
+  }
+  await close();
+});
+
+describe("findOrCreateMechanic", () => {
+  it("creates a vendor and dedupes case-insensitively", async () => {
+    const name = `Desert 4x4 Test ${stamp}`;
+    const first = await findOrCreateMechanic({ name, location: "Reno, NV" });
+    createdIds.push(first.id);
+    expect(first.name).toBe(name);
+    expect(first.location).toBe("Reno, NV");
+
+    const second = await findOrCreateMechanic({
+      name: name.toUpperCase(),
+      location: "Sparks, NV",
+    });
+    expect(second.id).toBe(first.id);
+    // Original location wins once set.
+    expect(second.location).toBe("Reno, NV");
+  });
+
+  it("backfills a missing location from a later receipt", async () => {
+    const name = `No Location Garage ${stamp}`;
+    const first = await findOrCreateMechanic({ name });
+    createdIds.push(first.id);
+    expect(first.location).toBe("");
+
+    const second = await findOrCreateMechanic({
+      name,
+      location: "Fernley, NV",
+    });
+    expect(second.id).toBe(first.id);
+    expect(second.location).toBe("Fernley, NV");
+
+    const [row] = await db
+      .select()
+      .from(mechanics)
+      .where(eq(mechanics.id, first.id));
+    expect(row?.location).toBe("Fernley, NV");
+  });
+
+  it("rejects empty names", async () => {
+    await expect(findOrCreateMechanic({ name: "   " })).rejects.toThrow(
+      "Vendor name is required",
+    );
+  });
+});

--- a/app/models/mechanic.server.ts
+++ b/app/models/mechanic.server.ts
@@ -1,0 +1,50 @@
+import { eq, sql } from "drizzle-orm";
+
+import { getDb } from "~/db/client";
+import type { Mechanic } from "~/db/schema";
+import { mechanics } from "~/db/schema";
+
+export type { Mechanic };
+
+/**
+ * Find a vendor by name (case-insensitive) or create it. Vendors come from
+ * scanned receipts and the log forms' Shop field, so the same shop arrives
+ * with varying capitalization — "Desert 4x4" and "DESERT 4X4" should be one
+ * filterable vendor, not two.
+ */
+export async function findOrCreateMechanic({
+  name,
+  location,
+}: {
+  name: string;
+  location?: string | null;
+}): Promise<Mechanic> {
+  const trimmed = name.trim();
+  if (!trimmed) throw new Error("Vendor name is required");
+
+  const db = await getDb();
+  const [existing] = await db
+    .select()
+    .from(mechanics)
+    .where(sql`lower(${mechanics.name}) = lower(${trimmed})`)
+    .limit(1);
+  if (existing) {
+    // Backfill a location learned from a later receipt.
+    if (!existing.location && location?.trim()) {
+      const [updated] = await db
+        .update(mechanics)
+        .set({ location: location.trim() })
+        .where(eq(mechanics.id, existing.id))
+        .returning();
+      return updated ?? existing;
+    }
+    return existing;
+  }
+
+  const [created] = await db
+    .insert(mechanics)
+    .values({ name: trimmed, location: location?.trim() ?? "" })
+    .returning();
+  if (!created) throw new Error("Failed to create vendor");
+  return created;
+}

--- a/app/routes/_authed.vehicles.$vehicleId.logs.$logId.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.logs.$logId.tsx
@@ -206,7 +206,7 @@ function LogDetail() {
         <div>
           <dt className="text-ink-muted">Who did it</dt>
           <dd className="mt-0.5 font-semibold text-ink">
-            {log.selfService ? "DIY 🔧" : "Shop"}
+            {log.selfService ? "DIY 🔧" : (log.mechanicName ?? "Shop")}
           </dd>
         </div>
       </dl>

--- a/app/routes/_authed.vehicles.$vehicleId.logs.index.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.logs.index.tsx
@@ -2,22 +2,53 @@ import {
   createFileRoute,
   getRouteApi,
   Link,
+  useNavigate,
   useParams,
 } from "@tanstack/react-router";
 
-import { btnPrimary, btnSecondary, card } from "~/components/ui";
+import { btnPrimary, btnSecondary, card, chip } from "~/components/ui";
 
 const logsApi = getRouteApi("/_authed/vehicles/$vehicleId/logs");
 
+type LogsSearch = { vendor?: string };
+
 export const Route = createFileRoute("/_authed/vehicles/$vehicleId/logs/")({
+  validateSearch: (search: Record<string, unknown>): LogsSearch => ({
+    vendor: typeof search.vendor === "string" ? search.vendor : undefined,
+  }),
   component: LogsList,
 });
 
 function LogsList() {
+  const navigate = useNavigate();
   const { vehicleId } = useParams({
     from: "/_authed/vehicles/$vehicleId/logs/",
   });
-  const logs = logsApi.useLoaderData();
+  const { vendor } = Route.useSearch();
+  const allLogs = logsApi.useLoaderData();
+
+  // Vendors come straight from the loaded list — no extra query, and the
+  // chips only ever show shops present in this vehicle's history.
+  const vendors = Array.from(
+    new Set(
+      allLogs
+        .map((l) => l.mechanicName)
+        .filter((name): name is string => name != null),
+    ),
+  );
+  const logs = vendor
+    ? allLogs.filter((l) => l.mechanicName === vendor)
+    : allLogs;
+
+  function setVendor(next: string | undefined) {
+    navigate({
+      to: "/vehicles/$vehicleId/logs",
+      params: { vehicleId },
+      search: next ? { vendor: next } : {},
+      replace: true,
+    });
+  }
+
   return (
     <section>
       <div className="flex items-center justify-between gap-3">
@@ -39,9 +70,34 @@ function LogsList() {
           </Link>
         </div>
       </div>
+
+      {vendors.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          <button
+            type="button"
+            className={chip(!vendor)}
+            onClick={() => setVendor(undefined)}
+          >
+            All
+          </button>
+          {vendors.map((name) => (
+            <button
+              key={name}
+              type="button"
+              className={chip(vendor === name)}
+              onClick={() => setVendor(vendor === name ? undefined : name)}
+            >
+              {name}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
       {logs.length === 0 ? (
         <p className="mt-6 text-sm text-ink-muted">
-          Nothing logged yet — hit “Log work” after the next job.
+          {vendor
+            ? `No logs from ${vendor} yet.`
+            : "Nothing logged yet — hit “Log work” after the next job."}
         </p>
       ) : (
         <ul className={`${card} mt-6 divide-y divide-line`}>
@@ -69,6 +125,7 @@ function LogsList() {
                   {log.odometer != null
                     ? ` · ${Math.round(log.odometer).toLocaleString()} mi`
                     : ""}
+                  {log.mechanicName ? ` · ${log.mechanicName}` : ""}
                   {log.authorName ? ` · ${log.authorName}` : ""}
                   {log.selfService ? " · DIY" : ""}
                 </div>

--- a/app/routes/_authed.vehicles.$vehicleId.logs.new.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.logs.new.tsx
@@ -17,6 +17,7 @@ import {
   textarea,
 } from "~/components/ui";
 import { createLog } from "~/models/log.server";
+import { findOrCreateMechanic } from "~/models/mechanic.server";
 import { completeReminder, getReminder } from "~/models/reminder.server";
 
 // Tap-to-fill presets so common jobs don't need typing in the shop.
@@ -69,6 +70,11 @@ const createLogFn = createServerFn({ method: "POST" })
     const odometer = odometerRaw ? Number.parseFloat(odometerRaw) : null;
     const servicedAt = servicedAtRaw ? new Date(servicedAtRaw) : new Date();
 
+    const shopName = String(data.get("shopName") ?? "").trim();
+    const mechanic = shopName
+      ? await findOrCreateMechanic({ name: shopName })
+      : null;
+
     const log = await createLog({
       userId,
       vehicleId,
@@ -79,6 +85,7 @@ const createLogFn = createServerFn({ method: "POST" })
       odometer,
       servicedAt,
       selfService,
+      mechanicId: mechanic?.id ?? null,
     });
 
     // Logging the work knocks out the reminder that prompted it —
@@ -230,6 +237,15 @@ function NewLog() {
         <label className={label}>
           Notes — torque specs, part numbers, what you'd do differently
           <textarea name="notes" rows={4} className={textarea} />
+        </label>
+
+        <label className={label}>
+          Shop (if not DIY) — filter your history by vendor later
+          <input
+            name="shopName"
+            placeholder="Desert 4x4 Service Center"
+            className={input}
+          />
         </label>
 
         <div className="grid grid-cols-2 items-end gap-3">

--- a/app/routes/_authed.vehicles.$vehicleId.scan.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.scan.tsx
@@ -77,6 +77,8 @@ const saveScanFn = createServerFn({ method: "POST" })
 
     const notes = String(data.get("notes") ?? "").trim() || null;
     const type = String(data.get("type") ?? "").trim() || null;
+    const shopName = String(data.get("shopName") ?? "").trim();
+    const shopLocation = String(data.get("shopLocation") ?? "").trim() || null;
     const reminderNotes =
       String(data.get("reminderNotes") ?? "").trim() || null;
     const draftReminder = data.get("draftReminder") === "on" && reminderNotes;
@@ -100,6 +102,7 @@ const saveScanFn = createServerFn({ method: "POST" })
           : servicedAt,
         selfService: data.get("selfService") === "on",
       },
+      vendor: shopName ? { name: shopName, location: shopLocation } : null,
       scan: {
         body: new Uint8Array(await checked.file.arrayBuffer()),
         contentType: checked.file.type,
@@ -173,6 +176,8 @@ function ScanReceipt() {
   const [odometer, setOdometer] = useState("");
   const [servicedAt, setServicedAt] = useState("");
   const [type, setType] = useState("");
+  const [shopName, setShopName] = useState("");
+  const [shopLocation, setShopLocation] = useState("");
   const [recommendedWork, setRecommendedWork] = useState<string | null>(null);
 
   function applyReceipt(receipt: ExtractedReceipt) {
@@ -181,6 +186,8 @@ function ScanReceipt() {
     setCost(receipt.totalCost != null ? String(receipt.totalCost) : "");
     setOdometer(receipt.odometer != null ? String(receipt.odometer) : "");
     setServicedAt(receipt.serviceDate ?? "");
+    setShopName(receipt.shopName ?? "");
+    setShopLocation(receipt.shopLocation ?? "");
     setRecommendedWork(receipt.recommendedWork);
   }
 
@@ -225,6 +232,8 @@ function ScanReceipt() {
     formData.set("title", title);
     formData.set("type", type);
     formData.set("notes", notes);
+    formData.set("shopName", shopName);
+    formData.set("shopLocation", shopLocation);
     try {
       const result = await saveScanFn({ data: formData });
       if (result && "error" in result && result.error) {
@@ -400,6 +409,16 @@ function ScanReceipt() {
               onChange={(e) => setNotes(e.target.value)}
               rows={6}
               className={textarea}
+            />
+          </label>
+
+          <label className={label}>
+            Shop — filter your history by vendor later
+            <input
+              value={shopName}
+              onChange={(e) => setShopName(e.target.value)}
+              placeholder="Desert 4x4 Service Center"
+              className={input}
             />
           </label>
 

--- a/app/scan/import.server.test.ts
+++ b/app/scan/import.server.test.ts
@@ -112,6 +112,26 @@ describe("createLogWithScan", () => {
     expect(result.reminder?.notes).toBe("pads at 5mm, replace in 5k mi");
   });
 
+  it("links the receipt's shop as a vendor on the log", async () => {
+    const vendorName = `Vendor Link Test ${Date.now()}`;
+    const result = await createLogWithScan({
+      userId,
+      vehicleId,
+      log: { title: "Diff fluid service", selfService: false },
+      vendor: { name: vendorName, location: "Reno, NV" },
+    });
+    expect(result.log.mechanicId).not.toBeNull();
+
+    // Same shop on a second receipt reuses the vendor row.
+    const again = await createLogWithScan({
+      userId,
+      vehicleId,
+      log: { title: "Diff fluid service round 2", selfService: false },
+      vendor: { name: vendorName.toUpperCase() },
+    });
+    expect(again.log.mechanicId).toBe(result.log.mechanicId);
+  });
+
   it("skips attachment and reminder when not provided", async () => {
     const result = await createLogWithScan({
       userId,

--- a/app/scan/import.server.ts
+++ b/app/scan/import.server.ts
@@ -13,6 +13,7 @@ import {
   type LogAttachment,
 } from "~/models/attachment.server";
 import { createLog, type Log } from "~/models/log.server";
+import { findOrCreateMechanic } from "~/models/mechanic.server";
 import { createReminder } from "~/models/reminder.server";
 import type { Storage } from "~/storage.server";
 
@@ -26,6 +27,7 @@ export async function createLogWithScan({
   userId,
   vehicleId,
   log,
+  vendor,
   scan,
   reminder,
   storage,
@@ -41,6 +43,11 @@ export async function createLogWithScan({
     servicedAt?: Date;
     selfService?: boolean;
   };
+  /**
+   * The shop that did the work (receipt's shopName). Linked to the log as a
+   * find-or-create `mechanics` row so logs are filterable by vendor.
+   */
+  vendor?: { name: string; location?: string | null } | null;
   /** The captured/scanned image to attach. Omit to just create the log. */
   scan?: ScanFile | null;
   /** Draft a follow-up reminder (from the tech's recommended-work note). */
@@ -52,7 +59,16 @@ export async function createLogWithScan({
   attachment: LogAttachment | null;
   reminder: Reminder | null;
 }> {
-  const created = await createLog({ userId, vehicleId, ...log });
+  const mechanic = vendor?.name.trim()
+    ? await findOrCreateMechanic(vendor)
+    : null;
+
+  const created = await createLog({
+    userId,
+    vehicleId,
+    ...log,
+    mechanicId: mechanic?.id ?? null,
+  });
 
   const attachment = scan
     ? await addLogAttachment({

--- a/scripts/scan-bay/import.ts
+++ b/scripts/scan-bay/import.ts
@@ -105,6 +105,9 @@ async function main() {
         servicedAt: r.serviceDate ? new Date(r.serviceDate) : new Date(),
         selfService: false,
       },
+      vendor: r.shopName
+        ? { name: r.shopName, location: r.shopLocation }
+        : null,
       scan: {
         body: new Uint8Array(bytes),
         contentType,


### PR DESCRIPTION
The extraction contract already pulled `shopName`/`shopLocation` from every receipt — it was just getting buried in the notes text. Now the shop is a first-class **vendor** on the log, so you can answer "show me everything Desert 4x4 has done to this Jeep."

**No migration**: this reuses the original schema's `mechanics` table and the `logs.mechanicId` FK, which existed but were written by nothing.

## What's here

- **`mechanic.server.ts`** — case-insensitive find-or-create ("Desert 4x4" and "DESERT 4X4" resolve to one vendor); location backfills from a later receipt if the first sighting didn't have one
- **Scan page**: a Shop field in the review form, prefilled from the receipt and editable before save
- **Batch CLI**: links the vendor the same way (shared `createLogWithScan` path)
- **Manual "Log work" form**: optional Shop field, so hand-entered shop visits are filterable too
- **Logs list**: vendor filter chips built from the vehicle's own history (no extra query — derived from the already-loaded list), selection kept in the URL; vendor shown in each row's metadata
- **Log detail**: "Who did it" now shows the shop's name instead of a generic "Shop"

## Verification

- End-to-end via **local Ollama** (the new zero-Cloudflare test loop): scanned the 18-item test invoice → Shop prefilled "DESERT 4x4 SERVICE CENTER" → saved → log detail shows the vendor → filter chip narrows 2 logs → 1, "All" restores
- `npm run validate` ✓ — **50/50 tests** (4 new: vendor dedupe + location backfill, empty-name rejection, vendor linking + reuse through `createLogWithScan`)

Also unrelated-but-included: `.tanstack/` codegen scratch dir added to `.gitignore` (one temp file nearly snuck into history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)