### PR TITLE
feat: odometer readings + vehicle editing with vPIC prefill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
    `logs.service_started_at` + `serviced_at`: service start and
    close/completion dates — a single-date receipt fills only the close;
    `odometer_readings`: standalone mileage entries (odometer, read_at, note,
-   author) — "last odometer" is latest-by-date across logs + manual readings,
+   user_id) — "last odometer" is latest-by-date across logs + manual readings,
    ties broken by higher miles)
 2. `app/db/client.ts` — postgres-js client, runtime-aware
 3. `app/db/migrations/` — generated SQL (do not edit by hand unless
@@ -162,7 +162,8 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
     `_authed.vehicles.$vehicleId.odometer.tsx` (current reading + source +
     quick-add form + history with author-or-owner delete), and
     `_authed.vehicles.$vehicleId.edit.tsx` (owner-only vehicle edit:
-    name/year/make/model/trim/engine/VIN/avatar)
+    name/year/make/model/trim/engine/VIN/avatar); `app/components/VehicleForm.tsx`
+    is the shared create/edit form (vPIC assists + avatar downscale)
 11. `wrangler.jsonc` — Cloudflare Workers config (Hyperdrive, R2, Workers
     AI, secrets). The `ai` binding is remote-only; dev keeps remote
     bindings OFF unless `CF_REMOTE_BINDINGS=1` (see vite.config.ts), so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,13 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
 1. `app/db/schema.ts` — all tables + pgvector + tsvector setup
    (incl. `log_attachments`: scans/photos/docs attached to a log;
    `vehicles.vin`: backfilled from receipts, never overwritten;
+   `vehicles.engine`: free-text engine description, filled by vPIC decode,
+   always user-editable;
    `logs.service_started_at` + `serviced_at`: service start and
-   close/completion dates — a single-date receipt fills only the close)
+   close/completion dates — a single-date receipt fills only the close;
+   `odometer_readings`: standalone mileage entries (odometer, read_at, note,
+   author) — "last odometer" is latest-by-date across logs + manual readings,
+   ties broken by higher miles)
 2. `app/db/client.ts` — postgres-js client, runtime-aware
 3. `app/db/migrations/` — generated SQL (do not edit by hand unless
    adding CREATE EXTENSION-style ops that Drizzle can't infer)
@@ -131,27 +136,44 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
    `attachment.server.ts` (log attachments — uploads via storage layer +
    row insert, access checked against the log's vehicle),
    `mechanic.server.ts` (vendors/shops — case-insensitive find-or-create;
-   logs link via `logs.mechanicId`, the logs list filters by vendor)
-8. `app/scan/` — Scan Bay. `receipt.ts` is the isomorphic extraction
+   logs link via `logs.mechanicId`, the logs list filters by vendor),
+   `odometer.server.ts` (union latest across logs + manual readings, batch
+   helper, history, create/delete — deletes restricted to author-or-owner),
+   `vehicle-form.server.ts` (shared parse + avatar store + avatar reap for
+   create and edit routes)
+8. `app/lib/` — isomorphic client utilities (safe to call from route
+   components): `image.ts` (`downscaleImage` — shared JPEG downscale used
+   by the scan page ~1600px and avatar uploads ~1024px; deliberately NOT
+   named `.client.ts` because TanStack Start's import-protection denies
+   `*.client.*` imports from SSR-reachable route components — functions are
+   only called inside browser event handlers), `vpic.ts` (NHTSA vPIC
+   client — VIN decode prefills year/make/model/trim/engine; make/model
+   datalist suggestions; browser-direct CORS calls, no API key, 5s timeout,
+   degrades gracefully to plain free-text)
+9. `app/scan/` — Scan Bay. `receipt.ts` is the isomorphic extraction
    contract (JSON schema + prompt + `normalizeReceipt`/`receiptToNotes`);
    `extract.server.ts` is the runtime seam (Workers AI binding on CF,
    Ollama fallback on Node — `ollama.server.ts`); `import.server.ts` is
    `createLogWithScan` (log + attachment + optional reminder), shared by
    the batch CLI (`scripts/scan-bay/`) and the in-app scan page.
-9. `app/routes/*` — file-based routes, including `/files/$` streaming
-   route, `/account/export` JSON bundle endpoint, and
-   `_authed.vehicles.$vehicleId.scan.tsx` (in-app receipt scan)
-10. `wrangler.jsonc` — Cloudflare Workers config (Hyperdrive, R2, Workers
+10. `app/routes/*` — file-based routes, including `/files/$` streaming
+    route, `/account/export` JSON bundle endpoint,
+    `_authed.vehicles.$vehicleId.scan.tsx` (in-app receipt scan),
+    `_authed.vehicles.$vehicleId.odometer.tsx` (current reading + source +
+    quick-add form + history with author-or-owner delete), and
+    `_authed.vehicles.$vehicleId.edit.tsx` (owner-only vehicle edit:
+    name/year/make/model/trim/engine/VIN/avatar)
+11. `wrangler.jsonc` — Cloudflare Workers config (Hyperdrive, R2, Workers
     AI, secrets). The `ai` binding is remote-only; dev keeps remote
     bindings OFF unless `CF_REMOTE_BINDINGS=1` (see vite.config.ts), so
     `npm run dev` never requires `wrangler login`.
-11. `drizzle.config.ts` — Drizzle Kit config
-12. `tsr.config.json` — TanStack Router CLI config; drives
+12. `drizzle.config.ts` — Drizzle Kit config
+13. `tsr.config.json` — TanStack Router CLI config; drives
     `app/routeTree.gen.ts` generation (the file is gitignored, so
     `npm run typecheck` regenerates it via `tsr generate` first)
-13. `biome.json` — lint/format rules
-14. `Dockerfile` + `docker/s6-rc.d/` — single-container self-host image
-15. `docker-compose.yml` — dev Postgres only (not for self-host)
+14. `biome.json` — lint/format rules
+15. `Dockerfile` + `docker/s6-rc.d/` — single-container self-host image
+16. `docker-compose.yml` — dev Postgres only (not for self-host)
 
 ## Git conventions
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ What it does today:
   explicitly is intentionally allowed; scan-based backfill only fills a
   blank VIN.
 - **Avatar photos** — vehicle photos are downscaled client-side (≤ 1024px
-  JPEG) before upload, so 12 MB phone shots (including HEIC from Safari)
-  arrive as a few hundred KB.
+  JPEG) before upload, so 12 MB phone shots arrive as a few hundred KB.
+  (HEIC works in Safari, which can decode it; other browsers fall back to
+  the original file and the server's 2MB cap applies.)
 - **Garage Mode** — one tap flips the whole app to a high-contrast dark
   theme with bigger type and fat touch targets, for reading at arm's
   length under bad shop lighting. Mobile-first throughout.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ What it does today:
 
 - **Work logs** — quick-capture form with tap-to-fill presets (oil change,
   brake pads, …), odometer/cost, and full-text search.
+- **Odometer tracking** — standalone mileage entries (date + miles + optional
+  note) supplement work-log odometer readings. The dashboard chip shows the
+  latest reading with its date; the odometer page lists the full history with
+  source (linked service log or manual) and lets any crew member add a reading.
 - **Crew sharing** — invite someone by email to any vehicle; members see
   and log everything on shared vehicles (invites for new emails are
   claimed automatically at signup).
@@ -19,6 +23,16 @@ What it does today:
 - **Projects** — plan bigger builds (e.g. rally prep): parts with prices
   and links through a proposed → ordered → received → installed pipeline,
   estimated vs committed budget, and a countdown to a target date.
+- **Vehicle editing** — owners can update a vehicle's name, year, make,
+  model, trim, engine, VIN, and avatar photo at any time. Typing a VIN
+  calls the free NHTSA vPIC API directly from the browser (no key, no
+  server round-trip) to prefill year/make/model/trim/engine; make/model
+  fields offer datalist suggestions from the same source. Editing a VIN
+  explicitly is intentionally allowed; scan-based backfill only fills a
+  blank VIN.
+- **Avatar photos** — vehicle photos are downscaled client-side (≤ 1024px
+  JPEG) before upload, so 12 MB phone shots (including HEIC from Safari)
+  arrive as a few hundred KB.
 - **Garage Mode** — one tap flips the whole app to a high-contrast dark
   theme with bigger type and fat touch targets, for reading at arm's
   length under bad shop lighting. Mobile-first throughout.
@@ -318,6 +332,7 @@ out of the client bundle.
   "user": { "id": "...", "email": "...", "createdAt": "...", "updatedAt": "..." },
   "vehicles": [{ ..., "avatarUrl": "/files/..." }],
   "logs": [ ... ],
+  "odometerReadings": [ ... ],
   "mechanics": [ ... ],
   "tags": [ ... ],
   "parts": [ ... ],

--- a/app/components/VehicleForm.tsx
+++ b/app/components/VehicleForm.tsx
@@ -1,0 +1,250 @@
+import { useState } from "react";
+
+import {
+  btnPrimary,
+  btnSecondary,
+  errorBox,
+  input,
+  label as labelClass,
+} from "~/components/ui";
+import { downscaleImage } from "~/lib/image.client";
+import { decodeVin, getMakes, getModelsForMakeYear } from "~/lib/vpic";
+
+export type VehicleFormValues = {
+  name: string;
+  make: string;
+  model: string;
+  trim: string;
+  year: string;
+  vin: string;
+  engine: string;
+};
+
+const EMPTY: VehicleFormValues = {
+  name: "",
+  make: "",
+  model: "",
+  trim: "",
+  year: "",
+  vin: "",
+  engine: "",
+};
+
+type VinStatus = "idle" | "loading" | "done" | "failed";
+
+/**
+ * Shared create/edit vehicle form. Routes own the server functions; this
+ * component owns field state, the vPIC assists (VIN decode + make/model
+ * datalists — all best-effort, every field stays free-text), and avatar
+ * downscaling. Submits a FormData with keys: name, make, model, trim,
+ * year, vin, engine, avatar (file, optional).
+ */
+export function VehicleForm({
+  initialValues,
+  currentAvatarUrl,
+  submitLabel,
+  pending,
+  error,
+  onSubmit,
+}: {
+  initialValues?: Partial<VehicleFormValues>;
+  currentAvatarUrl?: string | null;
+  submitLabel: string;
+  pending: boolean;
+  error: string | null;
+  onSubmit: (formData: FormData) => Promise<void>;
+}) {
+  const [values, setValues] = useState<VehicleFormValues>({
+    ...EMPTY,
+    ...initialValues,
+  });
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [vinStatus, setVinStatus] = useState<VinStatus>("idle");
+  const [makes, setMakes] = useState<string[]>([]);
+  const [models, setModels] = useState<string[]>([]);
+
+  function set<K extends keyof VehicleFormValues>(
+    key: K,
+    value: VehicleFormValues[K],
+  ) {
+    setValues((v) => ({ ...v, [key]: value }));
+  }
+
+  async function onVinLookup() {
+    if (!values.vin.trim()) return;
+    setVinStatus("loading");
+    const decoded = await decodeVin(values.vin);
+    if (!decoded) {
+      setVinStatus("failed");
+      return;
+    }
+    setValues((v) => ({
+      ...v,
+      year: decoded.year || v.year,
+      make: decoded.make || v.make,
+      model: decoded.model || v.model,
+      trim: decoded.trim || v.trim,
+      engine: decoded.engine || v.engine,
+    }));
+    setVinStatus("done");
+  }
+
+  async function loadMakes() {
+    if (makes.length === 0) setMakes(await getMakes());
+  }
+
+  async function loadModels() {
+    const year = Number.parseInt(values.year, 10);
+    if (!values.make || !Number.isFinite(year)) return;
+    setModels(await getModelsForMakeYear(values.make, year));
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const fd = new FormData();
+    fd.set("name", values.name);
+    fd.set("make", values.make);
+    fd.set("model", values.model);
+    fd.set("trim", values.trim);
+    fd.set("year", values.year);
+    fd.set("vin", values.vin);
+    fd.set("engine", values.engine);
+    if (avatarFile && avatarFile.size > 0) {
+      fd.set(
+        "avatar",
+        await downscaleImage(avatarFile, { maxDim: 1024, quality: 0.85 }),
+      );
+    }
+    await onSubmit(fd);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-6 max-w-lg space-y-4">
+      {error ? <p className={errorBox}>{error}</p> : null}
+
+      <div className="flex items-end gap-2">
+        <label className={`${labelClass} flex-1`}>
+          VIN (optional) — look it up to prefill the rest
+          <input
+            value={values.vin}
+            onChange={(e) => {
+              set("vin", e.target.value);
+              setVinStatus("idle");
+            }}
+            placeholder="1C4HJXDG5JW123456"
+            className={`${input} font-mono uppercase`}
+          />
+        </label>
+        <button
+          type="button"
+          onClick={onVinLookup}
+          disabled={vinStatus === "loading" || !values.vin.trim()}
+          className={btnSecondary}
+        >
+          {vinStatus === "loading" ? "Looking up…" : "Look up"}
+        </button>
+      </div>
+      {vinStatus === "failed" ? (
+        <p className="text-sm text-warn">
+          Couldn't decode that VIN — fill the fields in below.
+        </p>
+      ) : null}
+      {vinStatus === "done" ? (
+        <p className="text-sm text-ok">
+          Prefilled from the VIN — check it over.
+        </p>
+      ) : null}
+
+      <label className={labelClass}>
+        Name (optional)
+        <input
+          value={values.name}
+          onChange={(e) => set("name", e.target.value)}
+          placeholder="Rally Rig"
+          className={input}
+        />
+      </label>
+      <label className={labelClass}>
+        Year
+        <input
+          type="number"
+          required
+          value={values.year}
+          onChange={(e) => set("year", e.target.value)}
+          className={input}
+        />
+      </label>
+      <label className={labelClass}>
+        Make
+        <input
+          required
+          value={values.make}
+          onChange={(e) => set("make", e.target.value)}
+          onFocus={loadMakes}
+          list="vehicle-makes"
+          className={input}
+        />
+      </label>
+      <datalist id="vehicle-makes">
+        {makes.map((m) => (
+          <option key={m} value={m} />
+        ))}
+      </datalist>
+      <label className={labelClass}>
+        Model
+        <input
+          required
+          value={values.model}
+          onChange={(e) => set("model", e.target.value)}
+          onFocus={loadModels}
+          list="vehicle-models"
+          className={input}
+        />
+      </label>
+      <datalist id="vehicle-models">
+        {models.map((m) => (
+          <option key={m} value={m} />
+        ))}
+      </datalist>
+      <label className={labelClass}>
+        Trim (optional)
+        <input
+          value={values.trim}
+          onChange={(e) => set("trim", e.target.value)}
+          placeholder="Rubicon"
+          className={input}
+        />
+      </label>
+      <label className={labelClass}>
+        Engine (optional)
+        <input
+          value={values.engine}
+          onChange={(e) => set("engine", e.target.value)}
+          placeholder="3.6L V6 Pentastar"
+          className={input}
+        />
+      </label>
+
+      {currentAvatarUrl ? (
+        <img
+          src={currentAvatarUrl}
+          alt="Current vehicle"
+          className="h-20 w-20 rounded-2xl object-cover"
+        />
+      ) : null}
+      <label className={labelClass}>
+        Photo (optional{currentAvatarUrl ? " — replaces the current one" : ""})
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setAvatarFile(e.target.files?.[0] ?? null)}
+          className="mt-1 block w-full text-sm text-ink"
+        />
+      </label>
+
+      <button type="submit" disabled={pending} className={btnPrimary}>
+        {pending ? "Saving…" : submitLabel}
+      </button>
+    </form>
+  );
+}

--- a/app/components/VehicleForm.tsx
+++ b/app/components/VehicleForm.tsx
@@ -7,7 +7,6 @@ import {
   input,
   label as labelClass,
 } from "~/components/ui";
-import { downscaleImage } from "~/lib/image.client";
 import { decodeVin, getMakes, getModelsForMakeYear } from "~/lib/vpic";
 
 export type VehicleFormValues = {
@@ -31,6 +30,36 @@ const EMPTY: VehicleFormValues = {
 };
 
 type VinStatus = "idle" | "loading" | "done" | "failed";
+
+/**
+ * Downscale a vehicle avatar before upload (canvas resize → JPEG re-encode).
+ * Falls back to the original file when the browser can't decode it.
+ */
+async function downscaleAvatar(file: File): Promise<File> {
+  const MAX_DIM = 1024;
+  const QUALITY = 0.85;
+  try {
+    const bitmap = await createImageBitmap(file);
+    const scale = Math.min(1, MAX_DIM / Math.max(bitmap.width, bitmap.height));
+    if (scale === 1 && file.type === "image/jpeg") return file;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+    canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return file;
+    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+
+    const blob = await new Promise<Blob | null>((res) =>
+      canvas.toBlob(res, "image/jpeg", QUALITY),
+    );
+    if (!blob) return file;
+    const base = file.name.replace(/\.\w+$/, "") || "avatar";
+    return new File([blob], `${base}.jpg`, { type: "image/jpeg" });
+  } catch {
+    return file;
+  }
+}
 
 /**
  * Shared create/edit vehicle form. Routes own the server functions; this
@@ -68,6 +97,9 @@ export function VehicleForm({
     value: VehicleFormValues[K],
   ) {
     setValues((v) => ({ ...v, [key]: value }));
+    // Make/year drive the model suggestions — drop the stale list so the
+    // next focus refetches for the new combination.
+    if (key === "make" || key === "year") setModels([]);
   }
 
   async function onVinLookup() {
@@ -110,10 +142,7 @@ export function VehicleForm({
     fd.set("vin", values.vin);
     fd.set("engine", values.engine);
     if (avatarFile && avatarFile.size > 0) {
-      fd.set(
-        "avatar",
-        await downscaleImage(avatarFile, { maxDim: 1024, quality: 0.85 }),
-      );
+      fd.set("avatar", await downscaleAvatar(avatarFile));
     }
     await onSubmit(fd);
   }

--- a/app/components/VehicleForm.tsx
+++ b/app/components/VehicleForm.tsx
@@ -7,6 +7,7 @@ import {
   input,
   label as labelClass,
 } from "~/components/ui";
+import { downscaleImage } from "~/lib/image";
 import { decodeVin, getMakes, getModelsForMakeYear } from "~/lib/vpic";
 
 export type VehicleFormValues = {
@@ -30,36 +31,6 @@ const EMPTY: VehicleFormValues = {
 };
 
 type VinStatus = "idle" | "loading" | "done" | "failed";
-
-/**
- * Downscale a vehicle avatar before upload (canvas resize → JPEG re-encode).
- * Falls back to the original file when the browser can't decode it.
- */
-async function downscaleAvatar(file: File): Promise<File> {
-  const MAX_DIM = 1024;
-  const QUALITY = 0.85;
-  try {
-    const bitmap = await createImageBitmap(file);
-    const scale = Math.min(1, MAX_DIM / Math.max(bitmap.width, bitmap.height));
-    if (scale === 1 && file.type === "image/jpeg") return file;
-
-    const canvas = document.createElement("canvas");
-    canvas.width = Math.max(1, Math.round(bitmap.width * scale));
-    canvas.height = Math.max(1, Math.round(bitmap.height * scale));
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return file;
-    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
-
-    const blob = await new Promise<Blob | null>((res) =>
-      canvas.toBlob(res, "image/jpeg", QUALITY),
-    );
-    if (!blob) return file;
-    const base = file.name.replace(/\.\w+$/, "") || "avatar";
-    return new File([blob], `${base}.jpg`, { type: "image/jpeg" });
-  } catch {
-    return file;
-  }
-}
 
 /**
  * Shared create/edit vehicle form. Routes own the server functions; this
@@ -142,7 +113,10 @@ export function VehicleForm({
     fd.set("vin", values.vin);
     fd.set("engine", values.engine);
     if (avatarFile && avatarFile.size > 0) {
-      fd.set("avatar", await downscaleAvatar(avatarFile));
+      fd.set(
+        "avatar",
+        await downscaleImage(avatarFile, { maxDim: 1024, quality: 0.85 }),
+      );
     }
     await onSubmit(fd);
   }

--- a/app/db/migrations/0006_noisy_firebrand.sql
+++ b/app/db/migrations/0006_noisy_firebrand.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "odometer_readings" (
+	"id" text PRIMARY KEY NOT NULL,
+	"odometer" double precision NOT NULL,
+	"read_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"note" text,
+	"user_id" text NOT NULL,
+	"vehicle_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "vehicles" ADD COLUMN "engine" text;--> statement-breakpoint
+ALTER TABLE "odometer_readings" ADD CONSTRAINT "odometer_readings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "odometer_readings" ADD CONSTRAINT "odometer_readings_vehicle_id_vehicles_id_fk" FOREIGN KEY ("vehicle_id") REFERENCES "public"."vehicles"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+CREATE INDEX "odometer_readings_vehicle_idx" ON "odometer_readings" USING btree ("vehicle_id");

--- a/app/db/migrations/meta/0006_snapshot.json
+++ b/app/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1477 @@
+{
+  "id": "8e55f2b7-6b90-4a13-9d49-9d5ec64c9f9c",
+  "prevId": "3c7dd506-46a2-443f-8a14-f349a35fc4d7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.log_attachments": {
+      "name": "log_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "log_attachments_log_idx": {
+          "name": "log_attachments_log_idx",
+          "columns": [
+            {
+              "expression": "log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "log_attachments_log_id_logs_id_fk": {
+          "name": "log_attachments_log_id_logs_id_fk",
+          "tableFrom": "log_attachments",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_started_at": {
+          "name": "service_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serviced_at": {
+          "name": "serviced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "self_service": {
+          "name": "self_service",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mechanic_id": {
+          "name": "mechanic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(\"logs\".\"title\", '') || ' ' || coalesce(\"logs\".\"notes\", ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_search_idx": {
+          "name": "logs_search_idx",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "logs_vehicle_idx": {
+          "name": "logs_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_user_idx": {
+          "name": "logs_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "logs_user_id_users_id_fk": {
+          "name": "logs_user_id_users_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "logs_vehicle_id_vehicles_id_fk": {
+          "name": "logs_vehicle_id_vehicles_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "logs_mechanic_id_mechanics_id_fk": {
+          "name": "logs_mechanic_id_mechanics_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "mechanics",
+          "columnsFrom": [
+            "mechanic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_to_parts": {
+      "name": "logs_to_parts",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logs_to_parts_log_id_logs_id_fk": {
+          "name": "logs_to_parts_log_id_logs_id_fk",
+          "tableFrom": "logs_to_parts",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "logs_to_parts_part_id_parts_id_fk": {
+          "name": "logs_to_parts_part_id_parts_id_fk",
+          "tableFrom": "logs_to_parts",
+          "tableTo": "parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "logs_to_parts_log_id_part_id_pk": {
+          "name": "logs_to_parts_log_id_part_id_pk",
+          "columns": [
+            "log_id",
+            "part_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_to_tags": {
+      "name": "logs_to_tags",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logs_to_tags_log_id_logs_id_fk": {
+          "name": "logs_to_tags_log_id_logs_id_fk",
+          "tableFrom": "logs_to_tags",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "logs_to_tags_tag_id_tags_id_fk": {
+          "name": "logs_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "logs_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "logs_to_tags_log_id_tag_id_pk": {
+          "name": "logs_to_tags_log_id_tag_id_pk",
+          "columns": [
+            "log_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mechanics": {
+      "name": "mechanics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mechanics_email_idx": {
+          "name": "mechanics_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.odometer_readings": {
+      "name": "odometer_readings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "odometer_readings_vehicle_idx": {
+          "name": "odometer_readings_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "odometer_readings_user_id_users_id_fk": {
+          "name": "odometer_readings_user_id_users_id_fk",
+          "tableFrom": "odometer_readings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "odometer_readings_vehicle_id_vehicles_id_fk": {
+          "name": "odometer_readings_vehicle_id_vehicles_id_fk",
+          "tableFrom": "odometer_readings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parts": {
+      "name": "parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passwords": {
+      "name": "passwords",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passwords_user_id_users_id_fk": {
+          "name": "passwords_user_id_users_id_fk",
+          "tableFrom": "passwords",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passwords_user_id_unique": {
+          "name": "passwords_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_items": {
+      "name": "project_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_items_project_idx": {
+          "name": "project_items_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_items_project_id_projects_id_fk": {
+          "name": "project_items_project_id_projects_id_fk",
+          "tableFrom": "project_items",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idea'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_vehicle_idx": {
+          "name": "projects_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_vehicle_id_vehicles_id_fk": {
+          "name": "projects_vehicle_id_vehicles_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "projects_created_by_id_users_id_fk": {
+          "name": "projects_created_by_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reminders": {
+      "name": "reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_miles": {
+          "name": "due_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_months": {
+          "name": "interval_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_miles": {
+          "name": "interval_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reminders_vehicle_idx": {
+          "name": "reminders_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reminders_vehicle_id_vehicles_id_fk": {
+          "name": "reminders_vehicle_id_vehicles_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "reminders_created_by_id_users_id_fk": {
+          "name": "reminders_created_by_id_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_invites": {
+      "name": "vehicle_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_invites_vehicle_email_idx": {
+          "name": "vehicle_invites_vehicle_email_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vehicle_invites_email_idx": {
+          "name": "vehicle_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_invites_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_invites_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_invites",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_invites_invited_by_id_users_id_fk": {
+          "name": "vehicle_invites_invited_by_id_users_id_fk",
+          "tableFrom": "vehicle_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_members": {
+      "name": "vehicle_members",
+      "schema": "",
+      "columns": {
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_members_user_idx": {
+          "name": "vehicle_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_members_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_members_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_members",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_members_user_id_users_id_fk": {
+          "name": "vehicle_members_user_id_users_id_fk",
+          "tableFrom": "vehicle_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vehicle_members_vehicle_id_user_id_pk": {
+          "name": "vehicle_members_vehicle_id_user_id_pk",
+          "columns": [
+            "vehicle_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trim": {
+          "name": "trim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vin": {
+          "name": "vin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine": {
+          "name": "engine",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vehicles_user_id_users_id_fk": {
+          "name": "vehicles_user_id_users_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/db/migrations/meta/_journal.json
+++ b/app/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1781222748692,
       "tag": "0005_optimal_microbe",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1781236125214,
+      "tag": "0006_noisy_firebrand",
+      "breakpoints": true
     }
   ]
 }

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -73,6 +73,9 @@ export const vehicles = pgTable("vehicles", {
   year: integer().notNull(),
   // 17-char VIN; backfilled from scanned shop receipts when missing.
   vin: text(),
+  // Free-text engine description, e.g. "3.6L V6 Pentastar". Filled by the
+  // vPIC VIN decode on the vehicle form, always user-editable.
+  engine: text(),
   avatarPath: text("avatar_path"),
   userId: text("user_id")
     .notNull()
@@ -315,6 +318,31 @@ export const logsToParts = pgTable(
   (t) => [primaryKey({ columns: [t.logId, t.partId] })],
 );
 
+export const odometerReadings = pgTable(
+  "odometer_readings",
+  {
+    id: cuid2().primaryKey(),
+    odometer: doublePrecision().notNull(),
+    // When the reading was taken. Date-only semantics (UTC midnight from an
+    // <input type="date">) — render with formatDateOnly.
+    readAt: timestamp("read_at", { withTimezone: true, mode: "date" })
+      .notNull()
+      .defaultNow(),
+    note: text(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade", onUpdate: "cascade" }),
+    vehicleId: text("vehicle_id")
+      .notNull()
+      .references(() => vehicles.id, {
+        onDelete: "cascade",
+        onUpdate: "cascade",
+      }),
+    ...timestamps,
+  },
+  (t) => [index("odometer_readings_vehicle_idx").on(t.vehicleId)],
+);
+
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type Vehicle = typeof vehicles.$inferSelect;
@@ -334,3 +362,5 @@ export type ProjectItem = typeof projectItems.$inferSelect;
 export type NewProjectItem = typeof projectItems.$inferInsert;
 export type LogAttachment = typeof logAttachments.$inferSelect;
 export type NewLogAttachment = typeof logAttachments.$inferInsert;
+export type OdometerReading = typeof odometerReadings.$inferSelect;
+export type NewOdometerReading = typeof odometerReadings.$inferInsert;

--- a/app/lib/image.client.ts
+++ b/app/lib/image.client.ts
@@ -1,0 +1,32 @@
+/**
+ * Shrink an image client-side before upload (canvas resize → JPEG re-encode).
+ * Falls back to the original file when the browser can't decode it (e.g.
+ * HEIC outside Safari) — server-side size caps still apply, so a failed
+ * downscale degrades to a clear server error rather than a broken upload.
+ */
+export async function downscaleImage(
+  file: File,
+  { maxDim, quality }: { maxDim: number; quality: number },
+): Promise<File> {
+  try {
+    const bitmap = await createImageBitmap(file);
+    const scale = Math.min(1, maxDim / Math.max(bitmap.width, bitmap.height));
+    if (scale === 1 && file.type === "image/jpeg") return file;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+    canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return file;
+    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+
+    const blob = await new Promise<Blob | null>((res) =>
+      canvas.toBlob(res, "image/jpeg", quality),
+    );
+    if (!blob) return file;
+    const base = file.name.replace(/\.\w+$/, "") || "image";
+    return new File([blob], `${base}.jpg`, { type: "image/jpeg" });
+  } catch {
+    return file;
+  }
+}

--- a/app/lib/image.ts
+++ b/app/lib/image.ts
@@ -3,6 +3,11 @@
  * Falls back to the original file when the browser can't decode it (e.g.
  * HEIC outside Safari) — server-side size caps still apply, so a failed
  * downscale degrades to a clear server error rather than a broken upload.
+ *
+ * Lives outside the `.client.*` naming pattern on purpose: route components
+ * are statically reachable from the SSR bundle, and merely defining these
+ * browser-API functions there is harmless — they're only called from event
+ * handlers.
  */
 export async function downscaleImage(
   file: File,

--- a/app/lib/vpic.test.ts
+++ b/app/lib/vpic.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { buildEngineString } from "~/lib/vpic";
+
+describe("buildEngineString", () => {
+  it("builds a V6 with displacement and engine model", () => {
+    expect(
+      buildEngineString({
+        DisplacementL: "3.6",
+        EngineCylinders: "6",
+        EngineConfiguration: "V-Shaped",
+        EngineModel: "Pentastar",
+      }),
+    ).toBe("3.6L V6 Pentastar");
+  });
+
+  it("builds an inline-4 turbo", () => {
+    expect(
+      buildEngineString({
+        DisplacementL: "2.0",
+        EngineCylinders: "4",
+        EngineConfiguration: "In-Line",
+        Turbo: "Yes",
+      }),
+    ).toBe("2.0L I4 Turbo");
+  });
+
+  it("handles missing configuration with a cylinder-count fallback", () => {
+    expect(
+      buildEngineString({ DisplacementL: "5.7", EngineCylinders: "8" }),
+    ).toBe("5.7L 8-cyl");
+  });
+
+  it("skips 'Not Applicable' engine models and empty fields", () => {
+    expect(buildEngineString({ EngineModel: "Not Applicable" })).toBe("");
+    expect(buildEngineString({})).toBe("");
+  });
+});

--- a/app/lib/vpic.ts
+++ b/app/lib/vpic.ts
@@ -1,0 +1,129 @@
+/**
+ * NHTSA vPIC lookups for the vehicle form. Client-only by design: vPIC
+ * supports CORS, so the browser calls it directly — no Worker egress,
+ * identical behavior on self-host. Every call degrades to "no data" on
+ * failure; the form treats that as normal (free-text entry).
+ */
+
+const VPIC_BASE = "https://vpic.nhtsa.dot.gov/api/vehicles";
+const TIMEOUT_MS = 5000;
+
+// biome-ignore lint/suspicious/noExplicitAny: vPIC's response envelope is untyped JSON.
+async function vpicFetch(path: string): Promise<any | null> {
+  try {
+    const res = await fetch(`${VPIC_BASE}/${path}`, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+function present(value: string | undefined): value is string {
+  return !!value && value !== "Not Applicable";
+}
+
+/** The subset of DecodeVinValues result fields we read. */
+export type VpicVinResult = {
+  ModelYear?: string;
+  Make?: string;
+  Model?: string;
+  Series?: string;
+  Trim?: string;
+  DisplacementL?: string;
+  EngineCylinders?: string;
+  EngineConfiguration?: string;
+  Turbo?: string;
+  EngineModel?: string;
+};
+
+/**
+ * "3.6L V6 Pentastar", "2.0L I4 Turbo" — built from vPIC's separate engine
+ * fields. Pure and exported for tests.
+ */
+export function buildEngineString(r: VpicVinResult): string {
+  const parts: string[] = [];
+
+  const liters = present(r.DisplacementL)
+    ? Number.parseFloat(r.DisplacementL)
+    : NaN;
+  if (Number.isFinite(liters)) parts.push(`${liters.toFixed(1)}L`);
+
+  const cylinders = present(r.EngineCylinders)
+    ? Number.parseInt(r.EngineCylinders, 10)
+    : NaN;
+  if (Number.isFinite(cylinders)) {
+    const config = (r.EngineConfiguration ?? "").toLowerCase();
+    const prefix = config.startsWith("v")
+      ? "V"
+      : config.includes("line")
+        ? "I"
+        : "";
+    parts.push(prefix ? `${prefix}${cylinders}` : `${cylinders}-cyl`);
+  }
+
+  if ((r.Turbo ?? "").toLowerCase() === "yes") parts.push("Turbo");
+  if (present(r.EngineModel)) parts.push(r.EngineModel);
+
+  return parts.join(" ");
+}
+
+/** vPIC SHOUTS make names ("JEEP") — title-case them for form fields. */
+function titleCase(s: string): string {
+  return s.toLowerCase().replace(/(^|[\s-])\w/g, (c) => c.toUpperCase());
+}
+
+export type DecodedVin = {
+  year: string;
+  make: string;
+  model: string;
+  trim: string;
+  engine: string;
+};
+
+export async function decodeVin(vin: string): Promise<DecodedVin | null> {
+  const trimmed = vin.trim().toUpperCase();
+  if (!trimmed) return null;
+  const json = await vpicFetch(
+    `DecodeVinValues/${encodeURIComponent(trimmed)}?format=json`,
+  );
+  const r: VpicVinResult | undefined = json?.Results?.[0];
+  if (!r || !present(r.Make)) return null;
+  return {
+    year: present(r.ModelYear) ? r.ModelYear : "",
+    make: titleCase(r.Make),
+    model: present(r.Model) ? r.Model : "",
+    trim: [r.Series, r.Trim].filter(present).join(" "),
+    engine: buildEngineString(r),
+  };
+}
+
+let makesCache: string[] | null = null;
+
+export async function getMakes(): Promise<string[]> {
+  if (makesCache) return makesCache;
+  const json = await vpicFetch("GetMakesForVehicleType/car?format=json");
+  const makes: string[] = (json?.Results ?? [])
+    .map((r: { MakeName?: string }) => r.MakeName)
+    .filter((m: string | undefined): m is string => !!m)
+    .map(titleCase)
+    .sort();
+  if (makes.length) makesCache = makes;
+  return makes;
+}
+
+export async function getModelsForMakeYear(
+  make: string,
+  year: number,
+): Promise<string[]> {
+  if (!make || !Number.isFinite(year)) return [];
+  const json = await vpicFetch(
+    `GetModelsForMakeYear/make/${encodeURIComponent(make)}/modelyear/${year}?format=json`,
+  );
+  return (json?.Results ?? [])
+    .map((r: { Model_Name?: string }) => r.Model_Name)
+    .filter((m: string | undefined): m is string => !!m)
+    .sort();
+}

--- a/app/models/log.server.ts
+++ b/app/models/log.server.ts
@@ -76,18 +76,6 @@ export async function getLogListItems({
   }));
 }
 
-/** Highest odometer ever logged for the vehicle (best guess at current). */
-export async function getLatestOdometer({
-  vehicleId,
-}: Pick<Log, "vehicleId">): Promise<number | null> {
-  const db = await getDb();
-  const [row] = await db
-    .select({ latest: sql<number | null>`max(${logs.odometer})` })
-    .from(logs)
-    .where(eq(logs.vehicleId, vehicleId));
-  return row?.latest ?? null;
-}
-
 export async function createLog(input: NewLog) {
   await requireVehicleAccess({
     vehicleId: input.vehicleId,

--- a/app/models/odometer.server.test.ts
+++ b/app/models/odometer.server.test.ts
@@ -10,7 +10,11 @@ import {
   getLatestOdometer,
   listOdometerHistory,
 } from "~/models/odometer.server";
-import { createReminder, listReminders } from "~/models/reminder.server";
+import {
+  completeReminder,
+  createReminder,
+  listReminders,
+} from "~/models/reminder.server";
 import { createVehicle } from "~/models/vehicle.server";
 
 // Integration test — requires DATABASE_URL pointing at a running local
@@ -300,5 +304,38 @@ describe("reminders use the union latest", () => {
     const oil = reminders.find((r) => r.title === "Oil change");
     expect(oil?.milesLeft).toBe(200);
     expect(oil?.status).toBe("due_soon");
+  });
+
+  it("completeReminder without an explicit odometer rolls forward from the union latest", async () => {
+    const vehicleId = await makeVehicle();
+    const reminder = await createReminder({
+      userId: ownerId,
+      vehicleId,
+      title: "Rotate tires",
+      dueMiles: 61_000,
+      intervalMiles: 5_000,
+    });
+    // Older log with HIGHER miles vs newer manual reading with LOWER miles —
+    // the roll-forward base must be the union latest (61,200), not max (62,000).
+    await createLog({
+      userId: ownerId,
+      vehicleId,
+      title: "Big service",
+      odometer: 62_000,
+      servicedAt: new Date("2026-01-01"),
+    });
+    await createOdometerReading({
+      vehicleId,
+      userId: ownerId,
+      odometer: 61_200,
+      readAt: new Date("2026-06-01"),
+    });
+    const rolled = await completeReminder({
+      id: reminder.id,
+      vehicleId,
+      userId: ownerId,
+    });
+    expect(rolled?.dueMiles).toBe(66_200); // 61,200 + 5,000
+    expect(rolled?.completedAt).toBeNull(); // recurring → stays active
   });
 });

--- a/app/models/odometer.server.test.ts
+++ b/app/models/odometer.server.test.ts
@@ -1,0 +1,304 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createDb } from "~/db/client";
+import { users, vehicleMembers } from "~/db/schema";
+import { createLog } from "~/models/log.server";
+import {
+  createOdometerReading,
+  deleteOdometerReading,
+  getLatestOdometer,
+  listOdometerHistory,
+} from "~/models/odometer.server";
+import { createReminder, listReminders } from "~/models/reminder.server";
+import { createVehicle } from "~/models/vehicle.server";
+
+// Integration test — requires DATABASE_URL pointing at a running local
+// Postgres with migrations applied.
+
+const url = process.env.DATABASE_URL;
+if (!url)
+  throw new Error("DATABASE_URL is required for odometer.server.test.ts");
+
+const { db, close } = createDb(url);
+
+let ownerId: string;
+let memberId: string;
+
+beforeAll(async () => {
+  const [owner] = await db
+    .insert(users)
+    .values({ email: `odo-owner-${Date.now()}@example.com` })
+    .returning();
+  if (!owner) throw new Error("owner insert failed");
+  ownerId = owner.id;
+
+  const [member] = await db
+    .insert(users)
+    .values({ email: `odo-member-${Date.now()}@example.com` })
+    .returning();
+  if (!member) throw new Error("member insert failed");
+  memberId = member.id;
+});
+
+afterAll(async () => {
+  await db.delete(users).where(eq(users.id, ownerId));
+  await db.delete(users).where(eq(users.id, memberId));
+  await close();
+});
+
+/** Fresh vehicle per test so latest/history assertions don't interfere. */
+async function makeVehicle() {
+  const vehicle = await createVehicle({
+    userId: ownerId,
+    make: "Jeep",
+    model: "Wrangler",
+    year: 2024,
+  });
+  await db
+    .insert(vehicleMembers)
+    .values({ vehicleId: vehicle.id, userId: memberId, role: "member" });
+  return vehicle.id;
+}
+
+describe("getLatestOdometer", () => {
+  it("returns null when there are no readings at all", async () => {
+    const vehicleId = await makeVehicle();
+    expect(await getLatestOdometer({ vehicleId })).toBeNull();
+  });
+
+  it("returns the latest log odometer with its service date", async () => {
+    const vehicleId = await makeVehicle();
+    await createLog({
+      userId: ownerId,
+      vehicleId,
+      title: "Old service",
+      odometer: 50_000,
+      servicedAt: new Date("2025-01-15"),
+    });
+    const log = await createLog({
+      userId: ownerId,
+      vehicleId,
+      title: "New service",
+      odometer: 55_000,
+      servicedAt: new Date("2026-03-01"),
+    });
+    const latest = await getLatestOdometer({ vehicleId });
+    expect(latest).toMatchObject({
+      odometer: 55_000,
+      source: "log",
+      logId: log.id,
+    });
+    expect(latest?.date.toISOString()).toBe(
+      new Date("2026-03-01").toISOString(),
+    );
+  });
+
+  it("prefers the most recent date across logs and manual readings", async () => {
+    const vehicleId = await makeVehicle();
+    // Log has HIGHER miles but an OLDER date — latest-by-date must win.
+    await createLog({
+      userId: ownerId,
+      vehicleId,
+      title: "Service",
+      odometer: 60_000,
+      servicedAt: new Date("2026-01-01"),
+    });
+    await createOdometerReading({
+      vehicleId,
+      userId: ownerId,
+      odometer: 59_000, // corrected reading, newer date
+      readAt: new Date("2026-05-01"),
+    });
+    const latest = await getLatestOdometer({ vehicleId });
+    expect(latest).toMatchObject({
+      odometer: 59_000,
+      source: "reading",
+      logId: null,
+    });
+  });
+
+  it("breaks same-date ties by higher miles", async () => {
+    const vehicleId = await makeVehicle();
+    const date = new Date("2026-04-01");
+    await createLog({
+      userId: ownerId,
+      vehicleId,
+      title: "Service",
+      odometer: 61_000,
+      servicedAt: date,
+    });
+    await createOdometerReading({
+      vehicleId,
+      userId: ownerId,
+      odometer: 61_250,
+      readAt: date,
+    });
+    const latest = await getLatestOdometer({ vehicleId });
+    expect(latest?.odometer).toBe(61_250);
+    expect(latest?.source).toBe("reading");
+  });
+});
+
+describe("createOdometerReading", () => {
+  it("rejects non-members", async () => {
+    const vehicleId = await makeVehicle();
+    const [stranger] = await db
+      .insert(users)
+      .values({ email: `odo-stranger-${Date.now()}@example.com` })
+      .returning();
+    if (!stranger) throw new Error("stranger insert failed");
+    try {
+      await expect(
+        createOdometerReading({
+          vehicleId,
+          userId: stranger.id,
+          odometer: 1000,
+        }),
+      ).rejects.toThrow("Vehicle not found");
+    } finally {
+      await db.delete(users).where(eq(users.id, stranger.id));
+    }
+  });
+
+  it("rejects non-positive and non-finite miles", async () => {
+    const vehicleId = await makeVehicle();
+    await expect(
+      createOdometerReading({ vehicleId, userId: ownerId, odometer: 0 }),
+    ).rejects.toThrow("positive");
+    await expect(
+      createOdometerReading({ vehicleId, userId: ownerId, odometer: NaN }),
+    ).rejects.toThrow("positive");
+  });
+
+  it("lets a crew member add a reading with note and date", async () => {
+    const vehicleId = await makeVehicle();
+    const reading = await createOdometerReading({
+      vehicleId,
+      userId: memberId,
+      odometer: 62_000,
+      readAt: new Date("2026-06-01"),
+      note: "Spotted at the trailhead",
+    });
+    expect(reading.odometer).toBe(62_000);
+    expect(reading.note).toBe("Spotted at the trailhead");
+    expect(reading.userId).toBe(memberId);
+  });
+});
+
+describe("deleteOdometerReading", () => {
+  it("allows the author and the owner, rejects other members", async () => {
+    const vehicleId = await makeVehicle();
+    const byMember = await createOdometerReading({
+      vehicleId,
+      userId: memberId,
+      odometer: 63_000,
+    });
+    const byOwner = await createOdometerReading({
+      vehicleId,
+      userId: ownerId,
+      odometer: 63_100,
+    });
+
+    // A member may not delete someone else's reading.
+    await expect(
+      deleteOdometerReading({
+        id: byOwner.id,
+        vehicleId,
+        userId: memberId,
+      }),
+    ).rejects.toThrow("author or the owner");
+
+    // The author may delete their own.
+    await deleteOdometerReading({
+      id: byMember.id,
+      vehicleId,
+      userId: memberId,
+    });
+    // The owner may delete anyone's.
+    await deleteOdometerReading({ id: byOwner.id, vehicleId, userId: ownerId });
+
+    expect(await getLatestOdometer({ vehicleId })).toBeNull();
+  });
+});
+
+describe("listOdometerHistory", () => {
+  it("merges both sources newest-first with source metadata", async () => {
+    const vehicleId = await makeVehicle();
+    const log = await createLog({
+      userId: ownerId,
+      vehicleId,
+      title: "Oil change",
+      odometer: 58_000,
+      servicedAt: new Date("2026-02-01"),
+    });
+    await createOdometerReading({
+      vehicleId,
+      userId: memberId,
+      odometer: 59_500,
+      readAt: new Date("2026-05-15"),
+      note: "dash check",
+    });
+
+    const history = await listOdometerHistory({ vehicleId, userId: memberId });
+    expect(history).toHaveLength(2);
+    expect(history[0]).toMatchObject({
+      source: "reading",
+      odometer: 59_500,
+      note: "dash check",
+      authorUserId: memberId,
+    });
+    expect(history[1]).toMatchObject({
+      source: "log",
+      odometer: 58_000,
+      logId: log.id,
+      logTitle: "Oil change",
+    });
+  });
+
+  it("rejects non-members", async () => {
+    const vehicleId = await makeVehicle();
+    const [stranger] = await db
+      .insert(users)
+      .values({ email: `odo-stranger2-${Date.now()}@example.com` })
+      .returning();
+    if (!stranger) throw new Error("stranger insert failed");
+    try {
+      await expect(
+        listOdometerHistory({ vehicleId, userId: stranger.id }),
+      ).rejects.toThrow("Vehicle not found");
+    } finally {
+      await db.delete(users).where(eq(users.id, stranger.id));
+    }
+  });
+});
+
+describe("reminders use the union latest", () => {
+  it("a manual reading newer than any log drives due-miles status", async () => {
+    const vehicleId = await makeVehicle();
+    await createReminder({
+      userId: ownerId,
+      vehicleId,
+      title: "Oil change",
+      dueMiles: 65_000,
+    });
+    await createLog({
+      userId: ownerId,
+      vehicleId,
+      title: "Service",
+      odometer: 60_000,
+      servicedAt: new Date("2026-01-01"),
+    });
+    // 64,800 manual reading → 200 miles left → due_soon (threshold 500).
+    await createOdometerReading({
+      vehicleId,
+      userId: ownerId,
+      odometer: 64_800,
+      readAt: new Date("2026-06-01"),
+    });
+    const reminders = await listReminders({ vehicleId, userId: ownerId });
+    const oil = reminders.find((r) => r.title === "Oil change");
+    expect(oil?.milesLeft).toBe(200);
+    expect(oil?.status).toBe("due_soon");
+  });
+});

--- a/app/models/odometer.server.ts
+++ b/app/models/odometer.server.ts
@@ -1,0 +1,241 @@
+import { and, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+
+import { getDb } from "~/db/client";
+import type { OdometerReading } from "~/db/schema";
+import { logs, odometerReadings, users } from "~/db/schema";
+import { requireVehicleAccess } from "~/models/member.server";
+
+export type { OdometerReading };
+
+export type LatestOdometer = {
+  odometer: number;
+  /** servicedAt for log-sourced readings, readAt for manual ones. */
+  date: Date;
+  source: "log" | "reading";
+  /** Set when the reading came from a work log. */
+  logId: string | null;
+};
+
+function isLater(a: LatestOdometer, b: LatestOdometer): boolean {
+  if (a.date.getTime() !== b.date.getTime()) {
+    return a.date.getTime() > b.date.getTime();
+  }
+  return a.odometer > b.odometer;
+}
+
+/**
+ * Latest reading per vehicle across work logs and manual readings — most
+ * recent by date, same-date ties broken by higher miles. Deliberately NOT
+ * max(miles): a typo'd entry can be deleted to roll the value back, while
+ * max() could never go down. No access check — internal helper; callers
+ * either check membership themselves or pass server-derived vehicle ids.
+ */
+export async function getLatestOdometerByVehicle({
+  vehicleIds,
+}: {
+  vehicleIds: string[];
+}): Promise<Map<string, LatestOdometer>> {
+  const result = new Map<string, LatestOdometer>();
+  if (vehicleIds.length === 0) return result;
+  const db = await getDb();
+
+  const logRows = await db
+    .selectDistinctOn([logs.vehicleId], {
+      vehicleId: logs.vehicleId,
+      odometer: logs.odometer,
+      date: logs.servicedAt,
+      logId: logs.id,
+    })
+    .from(logs)
+    .where(and(inArray(logs.vehicleId, vehicleIds), isNotNull(logs.odometer)))
+    .orderBy(logs.vehicleId, desc(logs.servicedAt), desc(logs.odometer));
+
+  const readingRows = await db
+    .selectDistinctOn([odometerReadings.vehicleId], {
+      vehicleId: odometerReadings.vehicleId,
+      odometer: odometerReadings.odometer,
+      date: odometerReadings.readAt,
+    })
+    .from(odometerReadings)
+    .where(inArray(odometerReadings.vehicleId, vehicleIds))
+    .orderBy(
+      odometerReadings.vehicleId,
+      desc(odometerReadings.readAt),
+      desc(odometerReadings.odometer),
+    );
+
+  for (const r of logRows) {
+    if (r.odometer == null) continue;
+    result.set(r.vehicleId, {
+      odometer: r.odometer,
+      date: r.date,
+      source: "log",
+      logId: r.logId,
+    });
+  }
+  for (const r of readingRows) {
+    const candidate: LatestOdometer = {
+      odometer: r.odometer,
+      date: r.date,
+      source: "reading",
+      logId: null,
+    };
+    const existing = result.get(r.vehicleId);
+    if (!existing || isLater(candidate, existing)) {
+      result.set(r.vehicleId, candidate);
+    }
+  }
+  return result;
+}
+
+export async function getLatestOdometer({
+  vehicleId,
+}: {
+  vehicleId: string;
+}): Promise<LatestOdometer | null> {
+  const byVehicle = await getLatestOdometerByVehicle({
+    vehicleIds: [vehicleId],
+  });
+  return byVehicle.get(vehicleId) ?? null;
+}
+
+export type OdometerHistoryEntry = {
+  odometer: number;
+  date: Date;
+  source: "log" | "reading";
+  logId: string | null;
+  logTitle: string | null;
+  readingId: string | null;
+  note: string | null;
+  authorName: string | null;
+  authorUserId: string | null;
+};
+
+/** Full reading history, newest first (ties: higher miles first). */
+export async function listOdometerHistory({
+  vehicleId,
+  userId,
+}: {
+  vehicleId: string;
+  userId: string;
+}): Promise<OdometerHistoryEntry[]> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+
+  const logRows = await db
+    .select({
+      odometer: logs.odometer,
+      date: logs.servicedAt,
+      logId: logs.id,
+      logTitle: logs.title,
+    })
+    .from(logs)
+    .where(and(eq(logs.vehicleId, vehicleId), isNotNull(logs.odometer)));
+
+  const readingRows = await db
+    .select({
+      odometer: odometerReadings.odometer,
+      date: odometerReadings.readAt,
+      readingId: odometerReadings.id,
+      note: odometerReadings.note,
+      authorUserId: odometerReadings.userId,
+      authorName: sql<
+        string | null
+      >`coalesce(${users.displayName}, ${users.email})`,
+    })
+    .from(odometerReadings)
+    .leftJoin(users, eq(users.id, odometerReadings.userId))
+    .where(eq(odometerReadings.vehicleId, vehicleId));
+
+  const entries: OdometerHistoryEntry[] = [
+    ...logRows.map((r) => ({
+      // isNotNull() in the WHERE guarantees this; Drizzle can't narrow it.
+      odometer: r.odometer as number,
+      date: r.date,
+      source: "log" as const,
+      logId: r.logId,
+      logTitle: r.logTitle,
+      readingId: null,
+      note: null,
+      authorName: null,
+      authorUserId: null,
+    })),
+    ...readingRows.map((r) => ({
+      odometer: r.odometer,
+      date: r.date,
+      source: "reading" as const,
+      logId: null,
+      logTitle: null,
+      readingId: r.readingId,
+      note: r.note,
+      authorName: r.authorName,
+      authorUserId: r.authorUserId,
+    })),
+  ];
+  return entries.sort(
+    (a, b) => b.date.getTime() - a.date.getTime() || b.odometer - a.odometer,
+  );
+}
+
+export async function createOdometerReading({
+  vehicleId,
+  userId,
+  odometer,
+  readAt,
+  note,
+}: {
+  vehicleId: string;
+  userId: string;
+  odometer: number;
+  readAt?: Date | null;
+  note?: string | null;
+}): Promise<OdometerReading> {
+  await requireVehicleAccess({ vehicleId, userId });
+  if (!Number.isFinite(odometer) || odometer <= 0) {
+    throw new Error("Odometer must be a positive number");
+  }
+  const db = await getDb();
+  const [reading] = await db
+    .insert(odometerReadings)
+    .values({
+      vehicleId,
+      userId,
+      odometer,
+      note: note?.trim() || null,
+      ...(readAt ? { readAt } : {}),
+    })
+    .returning();
+  if (!reading) throw new Error("Failed to save reading");
+  return reading;
+}
+
+/**
+ * Manual readings only — log-sourced values are corrected on the log
+ * itself. The reading's author or the vehicle owner may delete.
+ */
+export async function deleteOdometerReading({
+  id,
+  vehicleId,
+  userId,
+}: {
+  id: string;
+  vehicleId: string;
+  userId: string;
+}): Promise<void> {
+  const role = await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const [reading] = await db
+    .select()
+    .from(odometerReadings)
+    .where(
+      and(
+        eq(odometerReadings.id, id),
+        eq(odometerReadings.vehicleId, vehicleId),
+      ),
+    );
+  if (!reading) throw new Error("Reading not found");
+  if (reading.userId !== userId && role !== "owner") {
+    throw new Error("Only the author or the owner can delete a reading");
+  }
+  await db.delete(odometerReadings).where(eq(odometerReadings.id, id));
+}

--- a/app/models/reminder.server.ts
+++ b/app/models/reminder.server.ts
@@ -3,8 +3,8 @@ import { and, eq } from "drizzle-orm";
 import { getDb } from "~/db/client";
 import type { NewReminder, Reminder } from "~/db/schema";
 import { reminders } from "~/db/schema";
-import { getLatestOdometer } from "~/models/log.server";
 import { requireVehicleAccess } from "~/models/member.server";
+import { getLatestOdometer } from "~/models/odometer.server";
 
 export type { Reminder };
 
@@ -80,7 +80,7 @@ export async function listReminders({
     .select()
     .from(reminders)
     .where(eq(reminders.vehicleId, vehicleId));
-  const odometer = await getLatestOdometer({ vehicleId });
+  const odometer = (await getLatestOdometer({ vehicleId }))?.odometer ?? null;
 
   return rows
     .map((r) => ({ ...r, ...computeReminderStatus(r, odometer) }))
@@ -165,7 +165,8 @@ export async function completeReminder({
   }
   let nextDueMiles: number | null = null;
   if (reminder.intervalMiles != null) {
-    const base = odometer ?? (await getLatestOdometer({ vehicleId }));
+    const base =
+      odometer ?? (await getLatestOdometer({ vehicleId }))?.odometer ?? null;
     nextDueMiles =
       base != null
         ? base + reminder.intervalMiles

--- a/app/models/vehicle-form.server.ts
+++ b/app/models/vehicle-form.server.ts
@@ -1,0 +1,54 @@
+import { createId } from "@paralleldrive/cuid2";
+
+import { getStorage } from "~/storage.server";
+
+// The client downscales to ~1024px JPEG first; this is just headroom for
+// the PNG-passthrough path and defense-in-depth.
+export const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
+export const ALLOWED_AVATAR_TYPES = new Set(["image/png", "image/jpeg"]);
+
+/** Shared by the create and edit routes: parse + store an avatar upload. */
+export async function storeAvatarUpload(
+  data: FormData,
+  userId: string,
+): Promise<{ error: string } | { avatarPath: string | null }> {
+  const avatar = data.get("avatar");
+  if (!(avatar instanceof File) || avatar.size === 0) {
+    return { avatarPath: null };
+  }
+  if (avatar.size > MAX_AVATAR_BYTES) {
+    return { error: "Photo must be 2MB or smaller" };
+  }
+  if (!ALLOWED_AVATAR_TYPES.has(avatar.type)) {
+    return { error: "Photo must be PNG or JPEG" };
+  }
+  const bytes = new Uint8Array(await avatar.arrayBuffer());
+  const key = `vehicle-avatars/${userId}/${createId()}`;
+  await getStorage().upload(key, bytes, avatar.type);
+  return { avatarPath: key };
+}
+
+/** Shared by the create and edit routes: parse the VehicleForm fields. */
+export function parseVehicleFields(data: FormData):
+  | { error: string }
+  | {
+      name: string | null;
+      make: string;
+      model: string;
+      trim: string | null;
+      year: number;
+      vin: string | null;
+      engine: string | null;
+    } {
+  const name = String(data.get("name") ?? "").trim() || null;
+  const make = String(data.get("make") ?? "").trim();
+  const model = String(data.get("model") ?? "").trim();
+  const trim = String(data.get("trim") ?? "").trim() || null;
+  const year = Number.parseInt(String(data.get("year") ?? "").trim(), 10);
+  const vin = String(data.get("vin") ?? "").trim() || null;
+  const engine = String(data.get("engine") ?? "").trim() || null;
+  if (!make || !model || !Number.isFinite(year)) {
+    return { error: "Make, model, and year are required" };
+  }
+  return { name, make, model, trim, year, vin, engine };
+}

--- a/app/models/vehicle-form.server.ts
+++ b/app/models/vehicle-form.server.ts
@@ -28,6 +28,11 @@ export async function storeAvatarUpload(
   return { avatarPath: key };
 }
 
+/** Reap a replaced avatar's bytes once the row points at a new key. */
+export async function deleteStoredAvatar(path: string): Promise<void> {
+  await getStorage().delete(path);
+}
+
 /** Shared by the create and edit routes: parse the VehicleForm fields. */
 export function parseVehicleFields(data: FormData):
   | { error: string }

--- a/app/models/vehicle.server.test.ts
+++ b/app/models/vehicle.server.test.ts
@@ -1,0 +1,115 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createDb } from "~/db/client";
+import { users, vehicleMembers } from "~/db/schema";
+import { createVehicle, updateVehicle } from "~/models/vehicle.server";
+
+// Integration test — requires DATABASE_URL pointing at a running local
+// Postgres with migrations applied.
+
+const url = process.env.DATABASE_URL;
+if (!url)
+  throw new Error("DATABASE_URL is required for vehicle.server.test.ts");
+
+const { db, close } = createDb(url);
+
+let ownerId: string;
+let memberId: string;
+
+beforeAll(async () => {
+  const [owner] = await db
+    .insert(users)
+    .values({ email: `veh-owner-${Date.now()}@example.com` })
+    .returning();
+  if (!owner) throw new Error("owner insert failed");
+  ownerId = owner.id;
+  const [member] = await db
+    .insert(users)
+    .values({ email: `veh-member-${Date.now()}@example.com` })
+    .returning();
+  if (!member) throw new Error("member insert failed");
+  memberId = member.id;
+});
+
+afterAll(async () => {
+  await db.delete(users).where(eq(users.id, ownerId));
+  await db.delete(users).where(eq(users.id, memberId));
+  await close();
+});
+
+describe("updateVehicle", () => {
+  it("updates fields and normalizes the VIN", async () => {
+    const vehicle = await createVehicle({
+      userId: ownerId,
+      make: "Jeep",
+      model: "Wrangler",
+      year: 2024,
+    });
+    const updated = await updateVehicle({
+      id: vehicle.id,
+      userId: ownerId,
+      name: "Rally Rig",
+      make: "Jeep",
+      model: "Wrangler",
+      trim: "Rubicon",
+      year: 2024,
+      vin: " 1c4hjxdg5jw000000 ",
+      engine: "3.6L V6 Pentastar",
+    });
+    expect(updated.name).toBe("Rally Rig");
+    expect(updated.trim).toBe("Rubicon");
+    expect(updated.vin).toBe("1C4HJXDG5JW000000");
+    expect(updated.engine).toBe("3.6L V6 Pentastar");
+    // avatarPath untouched when not provided
+    expect(updated.avatarPath).toBeNull();
+  });
+
+  it("rejects non-owners (members included)", async () => {
+    const vehicle = await createVehicle({
+      userId: ownerId,
+      make: "Jeep",
+      model: "Wrangler",
+      year: 2024,
+    });
+    await db
+      .insert(vehicleMembers)
+      .values({ vehicleId: vehicle.id, userId: memberId, role: "member" });
+    await expect(
+      updateVehicle({
+        id: vehicle.id,
+        userId: memberId,
+        name: null,
+        make: "Honda",
+        model: "Civic",
+        trim: null,
+        year: 2020,
+        vin: null,
+        engine: null,
+      }),
+    ).rejects.toThrow("Only the owner");
+  });
+
+  it("replaces the avatar path only when provided", async () => {
+    const vehicle = await createVehicle({
+      userId: ownerId,
+      make: "Jeep",
+      model: "Wrangler",
+      year: 2024,
+      avatarPath: "vehicle-avatars/x/old",
+    });
+    const updated = await updateVehicle({
+      id: vehicle.id,
+      userId: ownerId,
+      name: null,
+      make: "Jeep",
+      model: "Wrangler",
+      trim: null,
+      year: 2024,
+      vin: null,
+      engine: null,
+      avatarPath: "vehicle-avatars/x/new",
+    });
+    expect(updated.avatarPath).toBe("vehicle-avatars/x/new");
+  });
+});

--- a/app/models/vehicle.server.ts
+++ b/app/models/vehicle.server.ts
@@ -4,7 +4,11 @@ import { getDb } from "~/db/client";
 import type { NewVehicle, Vehicle } from "~/db/schema";
 import { logs, reminders, vehicleMembers, vehicles } from "~/db/schema";
 import { deleteAttachmentBlobsForLogs } from "~/models/attachment.server";
-import { requireVehicleAccess, type VehicleRole } from "~/models/member.server";
+import {
+  requireVehicleAccess,
+  requireVehicleOwner,
+  type VehicleRole,
+} from "~/models/member.server";
 import { getLatestOdometerByVehicle } from "~/models/odometer.server";
 import type { Storage } from "~/storage.server";
 
@@ -150,6 +154,55 @@ export async function setVehicleVinIfMissing({
     .where(and(eq(vehicles.id, vehicleId), isNull(vehicles.vin)))
     .returning();
   return updated ?? null;
+}
+
+/**
+ * Owner-only edit of the vehicle's identity fields. Unlike the scan
+ * backfill, the owner explicitly editing the VIN here MAY change it.
+ * `avatarPath` is only written when the caller passes it (avatar
+ * replacement) — omitting it leaves the current photo alone.
+ */
+export async function updateVehicle({
+  id,
+  userId,
+  name,
+  make,
+  model,
+  trim,
+  year,
+  vin,
+  engine,
+  avatarPath,
+}: {
+  id: string;
+  userId: string;
+  name: string | null;
+  make: string;
+  model: string;
+  trim: string | null;
+  year: number;
+  vin: string | null;
+  engine: string | null;
+  avatarPath?: string | null;
+}): Promise<Vehicle> {
+  await requireVehicleOwner({ vehicleId: id, userId });
+  const db = await getDb();
+  const [updated] = await db
+    .update(vehicles)
+    .set({
+      name,
+      make,
+      model,
+      trim,
+      year,
+      vin: vin ? vin.trim().toUpperCase() : null,
+      engine,
+      ...(avatarPath !== undefined ? { avatarPath } : {}),
+    })
+    .where(eq(vehicles.id, id))
+    .returning();
+  if (!updated) throw new Error("Failed to update vehicle");
+  return updated;
 }
 
 /** Owner only — `userId` must match the vehicle's owner column. */

--- a/app/models/vehicle.server.ts
+++ b/app/models/vehicle.server.ts
@@ -1,10 +1,11 @@
-import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 
 import { getDb } from "~/db/client";
 import type { NewVehicle, Vehicle } from "~/db/schema";
 import { logs, reminders, vehicleMembers, vehicles } from "~/db/schema";
 import { deleteAttachmentBlobsForLogs } from "~/models/attachment.server";
 import { requireVehicleAccess, type VehicleRole } from "~/models/member.server";
+import { getLatestOdometerByVehicle } from "~/models/odometer.server";
 import type { Storage } from "~/storage.server";
 
 export type { Vehicle };
@@ -69,17 +70,7 @@ export async function getVehicleListItems({
 
   const vehicleIds = rows.map((r) => r.vehicle.id);
 
-  const odoRows = await db
-    .select({
-      vehicleId: logs.vehicleId,
-      latestOdometer: sql<number | null>`max(${logs.odometer})`,
-    })
-    .from(logs)
-    .where(inArray(logs.vehicleId, vehicleIds))
-    .groupBy(logs.vehicleId);
-  const odoByVehicle = new Map(
-    odoRows.map((r) => [r.vehicleId, r.latestOdometer]),
-  );
+  const latestByVehicle = await getLatestOdometerByVehicle({ vehicleIds });
 
   const reminderRows = await db
     .select()
@@ -95,7 +86,7 @@ export async function getVehicleListItems({
   const soonCutoff = now + DUE_SOON_DAYS * 24 * 60 * 60 * 1000;
   const alerts = new Map<string, { overdue: number; dueSoon: number }>();
   for (const r of reminderRows) {
-    const odo = odoByVehicle.get(r.vehicleId) ?? null;
+    const odo = latestByVehicle.get(r.vehicleId)?.odometer ?? null;
     const overdue =
       (r.dueDate != null && r.dueDate.getTime() <= now) ||
       (r.dueMiles != null && odo != null && odo >= r.dueMiles);
@@ -114,7 +105,7 @@ export async function getVehicleListItems({
   return rows.map(({ vehicle, role }) => ({
     ...vehicle,
     role: role as VehicleRole,
-    latestOdometer: odoByVehicle.get(vehicle.id) ?? null,
+    latestOdometer: latestByVehicle.get(vehicle.id)?.odometer ?? null,
     overdueCount: alerts.get(vehicle.id)?.overdue ?? 0,
     dueSoonCount: alerts.get(vehicle.id)?.dueSoon ?? 0,
   }));

--- a/app/routes/_authed.vehicles.$vehicleId.edit.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.edit.tsx
@@ -1,0 +1,119 @@
+import {
+  createFileRoute,
+  notFound,
+  useNavigate,
+  useRouter,
+} from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { useState } from "react";
+
+import { requireAuth } from "~/auth/session.server";
+import { VehicleForm } from "~/components/VehicleForm";
+import { getVehicle, updateVehicle } from "~/models/vehicle.server";
+import {
+  deleteStoredAvatar,
+  parseVehicleFields,
+  storeAvatarUpload,
+} from "~/models/vehicle-form.server";
+
+const loadVehicleForEditFn = createServerFn({ method: "GET" })
+  .inputValidator((vehicleId: string) => vehicleId)
+  .handler(async ({ data: vehicleId }) => {
+    const userId = await requireAuth();
+    const vehicle = await getVehicle({ id: vehicleId, userId });
+    // Owner-only: members can see the vehicle but not this form.
+    if (!vehicle || vehicle.role !== "owner") return null;
+    return vehicle;
+  });
+
+const updateVehicleFn = createServerFn({ method: "POST" })
+  .inputValidator((data: FormData) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    const vehicleId = String(data.get("vehicleId") ?? "");
+    if (!vehicleId) return { error: "Missing vehicle" };
+
+    const fields = parseVehicleFields(data);
+    if ("error" in fields) return { error: fields.error };
+
+    const stored = await storeAvatarUpload(data, userId);
+    if ("error" in stored) return { error: stored.error };
+
+    try {
+      const existing = await getVehicle({ id: vehicleId, userId });
+      const updated = await updateVehicle({
+        id: vehicleId,
+        userId,
+        ...fields,
+        ...(stored.avatarPath ? { avatarPath: stored.avatarPath } : {}),
+      });
+      // Reap the replaced photo's bytes once the row points at the new key.
+      if (stored.avatarPath && existing?.avatarPath) {
+        await deleteStoredAvatar(existing.avatarPath);
+      }
+      return { vehicleId: updated.id };
+    } catch (err) {
+      return {
+        error: err instanceof Error ? err.message : "Failed to save",
+      };
+    }
+  });
+
+export const Route = createFileRoute("/_authed/vehicles/$vehicleId/edit")({
+  component: EditVehiclePage,
+  loader: async ({ params }) => {
+    const vehicle = await loadVehicleForEditFn({ data: params.vehicleId });
+    if (!vehicle) throw notFound();
+    return vehicle;
+  },
+});
+
+function EditVehiclePage() {
+  const navigate = useNavigate();
+  const router = useRouter();
+  const v = Route.useLoaderData();
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(formData: FormData) {
+    setError(null);
+    setPending(true);
+    formData.set("vehicleId", v.id);
+    try {
+      const result = await updateVehicleFn({ data: formData });
+      if (result && "error" in result && result.error) {
+        setError(result.error);
+      } else {
+        // Refresh the layout loader so the header shows the new identity.
+        await router.invalidate();
+        navigate({ to: "/vehicles/$vehicleId", params: { vehicleId: v.id } });
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold text-ink">Edit vehicle</h2>
+      <VehicleForm
+        initialValues={{
+          name: v.name ?? "",
+          make: v.make,
+          model: v.model,
+          trim: v.trim ?? "",
+          year: String(v.year),
+          vin: v.vin ?? "",
+          engine: v.engine ?? "",
+        }}
+        currentAvatarUrl={v.avatarPath ? `/files/${v.avatarPath}` : null}
+        submitLabel="Save changes"
+        pending={pending}
+        error={error}
+        onSubmit={onSubmit}
+      />
+    </section>
+  );
+}

--- a/app/routes/_authed.vehicles.$vehicleId.edit.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.edit.tsx
@@ -36,11 +36,16 @@ const updateVehicleFn = createServerFn({ method: "POST" })
     const fields = parseVehicleFields(data);
     if ("error" in fields) return { error: fields.error };
 
+    // Authz + fetch the current row BEFORE touching storage.
+    const existing = await getVehicle({ id: vehicleId, userId });
+    if (!existing || existing.role !== "owner") {
+      return { error: "Only the owner can edit this vehicle" };
+    }
+
     const stored = await storeAvatarUpload(data, userId);
     if ("error" in stored) return { error: stored.error };
 
     try {
-      const existing = await getVehicle({ id: vehicleId, userId });
       const updated = await updateVehicle({
         id: vehicleId,
         userId,
@@ -48,8 +53,13 @@ const updateVehicleFn = createServerFn({ method: "POST" })
         ...(stored.avatarPath ? { avatarPath: stored.avatarPath } : {}),
       });
       // Reap the replaced photo's bytes once the row points at the new key.
-      if (stored.avatarPath && existing?.avatarPath) {
-        await deleteStoredAvatar(existing.avatarPath);
+      if (stored.avatarPath && existing.avatarPath) {
+        try {
+          await deleteStoredAvatar(existing.avatarPath);
+        } catch {
+          // Best-effort reap — the row already points at the new key, so a
+          // cleanup hiccup must not surface as a failed save.
+        }
       }
       return { vehicleId: updated.id };
     } catch (err) {

--- a/app/routes/_authed.vehicles.$vehicleId.index.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.index.tsx
@@ -288,16 +288,27 @@ function VehicleDashboard() {
         >
           📷 Scan receipt
         </Link>
-        <div className={`${card} flex items-center gap-3 px-5 py-3`}>
+        <Link
+          to="/vehicles/$vehicleId/odometer"
+          params={{ vehicleId: v.id }}
+          className={`${card} flex items-center gap-3 px-5 py-3 transition-colors hover:bg-sunken`}
+        >
           <span className="text-xs font-bold uppercase tracking-wide text-ink-muted">
-            Odometer
+            Last odometer
           </span>
-          <span className="text-xl font-bold tabular-nums text-ink">
-            {data.odometer != null
-              ? `${Math.round(data.odometer.odometer).toLocaleString()} mi`
-              : "—"}
+          <span className="flex flex-col">
+            <span className="text-xl font-bold tabular-nums text-ink">
+              {data.odometer != null
+                ? `${Math.round(data.odometer.odometer).toLocaleString()} mi`
+                : "—"}
+            </span>
+            {data.odometer != null ? (
+              <span className="text-xs text-ink-muted">
+                {formatDateOnly(data.odometer.date)}
+              </span>
+            ) : null}
           </span>
-        </div>
+        </Link>
       </div>
 
       <div className="grid gap-4 lg:grid-cols-2">

--- a/app/routes/_authed.vehicles.$vehicleId.index.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.index.tsx
@@ -18,13 +18,14 @@ import {
   errorBox,
   input,
 } from "~/components/ui";
-import { getLatestOdometer, getLogListItems } from "~/models/log.server";
+import { getLogListItems } from "~/models/log.server";
 import {
   inviteToCrew,
   listCrew,
   removeCrewMember,
   revokeInvite,
 } from "~/models/member.server";
+import { getLatestOdometer } from "~/models/odometer.server";
 import { listProjects } from "~/models/project.server";
 import { listReminders } from "~/models/reminder.server";
 import { deleteVehicle } from "~/models/vehicle.server";
@@ -293,7 +294,7 @@ function VehicleDashboard() {
           </span>
           <span className="text-xl font-bold tabular-nums text-ink">
             {data.odometer != null
-              ? `${Math.round(data.odometer).toLocaleString()} mi`
+              ? `${Math.round(data.odometer.odometer).toLocaleString()} mi`
               : "—"}
           </span>
         </div>

--- a/app/routes/_authed.vehicles.$vehicleId.index.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.index.tsx
@@ -441,7 +441,14 @@ function VehicleDashboard() {
       </div>
 
       {isOwner ? (
-        <div className="pt-4 text-right">
+        <div className="flex items-center justify-end gap-6 pt-4">
+          <Link
+            to="/vehicles/$vehicleId/edit"
+            params={{ vehicleId: v.id }}
+            className="text-sm font-semibold text-accent hover:underline"
+          >
+            Edit vehicle
+          </Link>
           <button
             type="button"
             onClick={onDelete}

--- a/app/routes/_authed.vehicles.$vehicleId.odometer.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.odometer.tsx
@@ -239,7 +239,7 @@ function OdometerPage() {
                 (isOwner || entry.authorUserId === userId) ? (
                   <button
                     type="button"
-                    className="shrink-0 text-xs font-semibold text-danger hover:underline"
+                    className="min-h-11 shrink-0 px-3 text-xs font-semibold text-danger hover:underline"
                     onClick={async () => {
                       if (!window.confirm("Delete this reading?")) return;
                       await deleteReadingFn({

--- a/app/routes/_authed.vehicles.$vehicleId.odometer.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.odometer.tsx
@@ -1,0 +1,264 @@
+import {
+  createFileRoute,
+  getRouteApi,
+  Link,
+  useRouter,
+} from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { useState } from "react";
+
+import { requireAuth } from "~/auth/session.server";
+import { formatDateOnly } from "~/components/format";
+import {
+  btnPrimary,
+  card,
+  errorBox,
+  input,
+  label as labelClass,
+} from "~/components/ui";
+import {
+  createOdometerReading,
+  deleteOdometerReading,
+  listOdometerHistory,
+} from "~/models/odometer.server";
+
+const parentApi = getRouteApi("/_authed/vehicles/$vehicleId");
+
+const loadOdometerFn = createServerFn({ method: "GET" })
+  .inputValidator((vehicleId: string) => vehicleId)
+  .handler(async ({ data: vehicleId }) => {
+    const userId = await requireAuth();
+    const history = await listOdometerHistory({ vehicleId, userId });
+    return { history, userId };
+  });
+
+const addReadingFn = createServerFn({ method: "POST" })
+  .inputValidator(
+    (data: {
+      vehicleId: string;
+      odometer: number;
+      readAt: string;
+      note: string;
+    }) => data,
+  )
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    try {
+      const readAt = new Date(data.readAt);
+      await createOdometerReading({
+        vehicleId: data.vehicleId,
+        userId,
+        odometer: data.odometer,
+        readAt: Number.isNaN(readAt.getTime()) ? null : readAt,
+        note: data.note || null,
+      });
+      return {};
+    } catch (err) {
+      return {
+        error: err instanceof Error ? err.message : "Failed to save reading",
+      };
+    }
+  });
+
+const deleteReadingFn = createServerFn({ method: "POST" })
+  .inputValidator((data: { vehicleId: string; readingId: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await deleteOdometerReading({
+      id: data.readingId,
+      vehicleId: data.vehicleId,
+      userId,
+    });
+  });
+
+export const Route = createFileRoute("/_authed/vehicles/$vehicleId/odometer")({
+  component: OdometerPage,
+  loader: async ({ params }) => loadOdometerFn({ data: params.vehicleId }),
+});
+
+/** Today as a YYYY-MM-DD string in UTC — matches date-only storage. */
+function todayInputValue(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function OdometerPage() {
+  const router = useRouter();
+  const v = parentApi.useLoaderData();
+  const { history, userId } = Route.useLoaderData();
+  const isOwner = v.role === "owner";
+  const latest = history[0] ?? null;
+
+  const [miles, setMiles] = useState("");
+  const [readAt, setReadAt] = useState(todayInputValue());
+  const [note, setNote] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onAdd(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setPending(true);
+    try {
+      const result = await addReadingFn({
+        data: {
+          vehicleId: v.id,
+          odometer: Number.parseFloat(miles),
+          readAt,
+          note: note.trim(),
+        },
+      });
+      if (result && "error" in result && result.error) {
+        setError(result.error);
+        return;
+      }
+      setMiles("");
+      setNote("");
+      setReadAt(todayInputValue());
+      await router.invalidate();
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <section className="mx-auto max-w-lg space-y-4">
+      <div className={`${card} p-5`}>
+        <h2 className="text-xs font-bold uppercase tracking-wide text-ink-muted">
+          Last odometer
+        </h2>
+        {latest ? (
+          <>
+            <p className="mt-1 text-3xl font-bold tabular-nums text-ink">
+              {Math.round(latest.odometer).toLocaleString()} mi
+            </p>
+            <p className="mt-1 text-sm text-ink-muted">
+              {formatDateOnly(latest.date)} ·{" "}
+              {latest.source === "log" && latest.logId ? (
+                <>
+                  from service:{" "}
+                  <Link
+                    to="/vehicles/$vehicleId/logs/$logId"
+                    params={{ vehicleId: v.id, logId: latest.logId }}
+                    className="font-semibold text-accent hover:underline"
+                  >
+                    {latest.logTitle}
+                  </Link>
+                </>
+              ) : (
+                "manual reading"
+              )}
+            </p>
+          </>
+        ) : (
+          <p className="mt-1 text-sm text-ink-muted">
+            No readings yet — log work with an odometer, or add one below.
+          </p>
+        )}
+      </div>
+
+      <form onSubmit={onAdd} className={`${card} space-y-3 p-5`}>
+        <h2 className="font-bold text-ink">Add a reading</h2>
+        {error ? <p className={errorBox}>{error}</p> : null}
+        <div className="grid grid-cols-2 gap-3">
+          <label className={labelClass}>
+            Miles
+            <input
+              type="number"
+              step="1"
+              min="1"
+              inputMode="numeric"
+              required
+              value={miles}
+              onChange={(e) => setMiles(e.target.value)}
+              className={`${input} text-lg font-semibold tabular-nums`}
+            />
+          </label>
+          <label className={labelClass}>
+            Date
+            <input
+              type="date"
+              required
+              value={readAt}
+              onChange={(e) => setReadAt(e.target.value)}
+              className={input}
+            />
+          </label>
+        </div>
+        <label className={labelClass}>
+          Note (optional)
+          <input
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Spotted before the trail run"
+            className={input}
+          />
+        </label>
+        <button type="submit" disabled={pending} className={btnPrimary}>
+          {pending ? "Saving…" : "Add reading"}
+        </button>
+      </form>
+
+      <div className={`${card} p-5`}>
+        <h2 className="font-bold text-ink">History</h2>
+        {history.length === 0 ? (
+          <p className="mt-2 text-sm text-ink-muted">Nothing recorded yet.</p>
+        ) : (
+          <ul className="mt-3 divide-y divide-line">
+            {history.map((entry) => (
+              <li
+                key={entry.readingId ?? `log-${entry.logId}`}
+                className="flex items-center justify-between gap-3 py-3"
+              >
+                <div className="min-w-0">
+                  <p className="font-semibold tabular-nums text-ink">
+                    {Math.round(entry.odometer).toLocaleString()} mi
+                  </p>
+                  <p className="truncate text-xs text-ink-muted">
+                    {formatDateOnly(entry.date)}
+                    {entry.source === "log" && entry.logId ? (
+                      <>
+                        {" · "}
+                        <Link
+                          to="/vehicles/$vehicleId/logs/$logId"
+                          params={{ vehicleId: v.id, logId: entry.logId }}
+                          className="text-accent hover:underline"
+                        >
+                          {entry.logTitle}
+                        </Link>
+                      </>
+                    ) : (
+                      <>
+                        {entry.authorName ? ` · ${entry.authorName}` : ""}
+                        {entry.note ? ` · ${entry.note}` : ""}
+                      </>
+                    )}
+                  </p>
+                </div>
+                {entry.source === "reading" &&
+                entry.readingId &&
+                (isOwner || entry.authorUserId === userId) ? (
+                  <button
+                    type="button"
+                    className="shrink-0 text-xs font-semibold text-danger hover:underline"
+                    onClick={async () => {
+                      if (!window.confirm("Delete this reading?")) return;
+                      await deleteReadingFn({
+                        data: {
+                          vehicleId: v.id,
+                          readingId: entry.readingId as string,
+                        },
+                      });
+                      await router.invalidate();
+                    }}
+                  >
+                    Delete
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/routes/_authed.vehicles.$vehicleId.scan.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.scan.tsx
@@ -18,6 +18,7 @@ import {
   label,
   textarea,
 } from "~/components/ui";
+import { downscaleImage } from "~/lib/image.client";
 import { requireVehicleAccess } from "~/models/member.server";
 import { extractReceiptScan } from "~/scan/extract.server";
 import { createLogWithScan } from "~/scan/import.server";
@@ -129,37 +130,6 @@ const saveScanFn = createServerFn({ method: "POST" })
     return { vehicleId, logId: log.id };
   });
 
-/**
- * Shrink a phone photo before upload: receipts read fine at 1600px and the
- * extraction round-trip drops from ~10 MB to a few hundred KB. Falls back to
- * the original file when the browser can't decode it (e.g. HEIC outside
- * Safari) — the server cap still applies.
- */
-async function downscaleForUpload(file: File): Promise<File> {
-  const MAX_DIM = 1600;
-  try {
-    const bitmap = await createImageBitmap(file);
-    const scale = Math.min(1, MAX_DIM / Math.max(bitmap.width, bitmap.height));
-    if (scale === 1 && file.type === "image/jpeg") return file;
-
-    const canvas = document.createElement("canvas");
-    canvas.width = Math.max(1, Math.round(bitmap.width * scale));
-    canvas.height = Math.max(1, Math.round(bitmap.height * scale));
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return file;
-    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
-
-    const blob = await new Promise<Blob | null>((res) =>
-      canvas.toBlob(res, "image/jpeg", 0.85),
-    );
-    if (!blob) return file;
-    const base = file.name.replace(/\.\w+$/, "") || "scan";
-    return new File([blob], `${base}.jpg`, { type: "image/jpeg" });
-  } catch {
-    return file;
-  }
-}
-
 export const Route = createFileRoute("/_authed/vehicles/$vehicleId/scan")({
   component: ScanReceipt,
 });
@@ -214,7 +184,10 @@ function ScanReceipt() {
   async function onPhotoPicked(picked: File | undefined) {
     if (!picked) return;
     setExtractError(null);
-    const upload = await downscaleForUpload(picked);
+    const upload = await downscaleImage(picked, {
+      maxDim: 1600,
+      quality: 0.85,
+    });
     setFile(upload);
     setPreview((old) => {
       if (old) URL.revokeObjectURL(old);

--- a/app/routes/_authed.vehicles.$vehicleId.scan.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.scan.tsx
@@ -18,7 +18,6 @@ import {
   label,
   textarea,
 } from "~/components/ui";
-import { downscaleImage } from "~/lib/image.client";
 import { requireVehicleAccess } from "~/models/member.server";
 import { extractReceiptScan } from "~/scan/extract.server";
 import { createLogWithScan } from "~/scan/import.server";
@@ -136,6 +135,37 @@ export const Route = createFileRoute("/_authed/vehicles/$vehicleId/scan")({
 
 type Step = "capture" | "reading" | "review";
 
+/**
+ * Shrink a phone photo before upload: receipts read fine at 1600px and the
+ * extraction round-trip drops from ~10 MB to a few hundred KB. Falls back to
+ * the original file when the browser can't decode it (e.g. HEIC outside
+ * Safari) — the server cap still applies.
+ */
+async function downscaleForUpload(file: File): Promise<File> {
+  const MAX_DIM = 1600;
+  try {
+    const bitmap = await createImageBitmap(file);
+    const scale = Math.min(1, MAX_DIM / Math.max(bitmap.width, bitmap.height));
+    if (scale === 1 && file.type === "image/jpeg") return file;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+    canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return file;
+    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+
+    const blob = await new Promise<Blob | null>((res) =>
+      canvas.toBlob(res, "image/jpeg", 0.85),
+    );
+    if (!blob) return file;
+    const base = file.name.replace(/\.\w+$/, "") || "scan";
+    return new File([blob], `${base}.jpg`, { type: "image/jpeg" });
+  } catch {
+    return file;
+  }
+}
+
 const vehicleApi = getRouteApi("/_authed/vehicles/$vehicleId");
 
 function ScanReceipt() {
@@ -184,10 +214,7 @@ function ScanReceipt() {
   async function onPhotoPicked(picked: File | undefined) {
     if (!picked) return;
     setExtractError(null);
-    const upload = await downscaleImage(picked, {
-      maxDim: 1600,
-      quality: 0.85,
-    });
+    const upload = await downscaleForUpload(picked);
     setFile(upload);
     setPreview((old) => {
       if (old) URL.revokeObjectURL(old);

--- a/app/routes/_authed.vehicles.$vehicleId.scan.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.scan.tsx
@@ -18,6 +18,7 @@ import {
   label,
   textarea,
 } from "~/components/ui";
+import { downscaleImage } from "~/lib/image";
 import { requireVehicleAccess } from "~/models/member.server";
 import { extractReceiptScan } from "~/scan/extract.server";
 import { createLogWithScan } from "~/scan/import.server";
@@ -135,37 +136,6 @@ export const Route = createFileRoute("/_authed/vehicles/$vehicleId/scan")({
 
 type Step = "capture" | "reading" | "review";
 
-/**
- * Shrink a phone photo before upload: receipts read fine at 1600px and the
- * extraction round-trip drops from ~10 MB to a few hundred KB. Falls back to
- * the original file when the browser can't decode it (e.g. HEIC outside
- * Safari) — the server cap still applies.
- */
-async function downscaleForUpload(file: File): Promise<File> {
-  const MAX_DIM = 1600;
-  try {
-    const bitmap = await createImageBitmap(file);
-    const scale = Math.min(1, MAX_DIM / Math.max(bitmap.width, bitmap.height));
-    if (scale === 1 && file.type === "image/jpeg") return file;
-
-    const canvas = document.createElement("canvas");
-    canvas.width = Math.max(1, Math.round(bitmap.width * scale));
-    canvas.height = Math.max(1, Math.round(bitmap.height * scale));
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return file;
-    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
-
-    const blob = await new Promise<Blob | null>((res) =>
-      canvas.toBlob(res, "image/jpeg", 0.85),
-    );
-    if (!blob) return file;
-    const base = file.name.replace(/\.\w+$/, "") || "scan";
-    return new File([blob], `${base}.jpg`, { type: "image/jpeg" });
-  } catch {
-    return file;
-  }
-}
-
 const vehicleApi = getRouteApi("/_authed/vehicles/$vehicleId");
 
 function ScanReceipt() {
@@ -214,7 +184,10 @@ function ScanReceipt() {
   async function onPhotoPicked(picked: File | undefined) {
     if (!picked) return;
     setExtractError(null);
-    const upload = await downscaleForUpload(picked);
+    const upload = await downscaleImage(picked, {
+      maxDim: 1600,
+      quality: 0.85,
+    });
     setFile(upload);
     setPreview((old) => {
       if (old) URL.revokeObjectURL(old);

--- a/app/routes/_authed.vehicles.$vehicleId.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.tsx
@@ -61,9 +61,11 @@ function VehicleLayout() {
             {v.name && v.trim ? ` ${v.trim}` : !v.name && v.trim ? v.trim : ""}
             {v.role === "member" ? " · shared with you" : ""}
           </p>
-          {v.vin ? (
-            <p className="truncate font-mono text-xs text-ink-muted">
-              VIN {v.vin}
+          {v.vin || v.engine ? (
+            <p className="truncate text-xs text-ink-muted">
+              {v.engine ?? ""}
+              {v.engine && v.vin ? " · " : ""}
+              {v.vin ? <span className="font-mono">VIN {v.vin}</span> : null}
             </p>
           ) : null}
         </div>

--- a/app/routes/_authed.vehicles.new.tsx
+++ b/app/routes/_authed.vehicles.new.tsx
@@ -4,57 +4,77 @@ import { createServerFn } from "@tanstack/react-start";
 import { useState } from "react";
 
 import { requireAuth } from "~/auth/session.server";
-import {
-  btnPrimary,
-  errorBox,
-  input,
-  label as labelClass,
-} from "~/components/ui";
+import { VehicleForm } from "~/components/VehicleForm";
 import { createVehicle } from "~/models/vehicle.server";
 import { getStorage } from "~/storage.server";
 
-const MAX_AVATAR_BYTES = 500 * 1024;
+// The client downscales to ~1024px JPEG first; this is just headroom for
+// the PNG-passthrough path and defense-in-depth.
+const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
 const ALLOWED_AVATAR_TYPES = new Set(["image/png", "image/jpeg"]);
+
+/** Shared by the create and edit routes: parse + store an avatar upload. */
+export async function storeAvatarUpload(
+  data: FormData,
+  userId: string,
+): Promise<{ error: string } | { avatarPath: string | null }> {
+  const avatar = data.get("avatar");
+  if (!(avatar instanceof File) || avatar.size === 0) {
+    return { avatarPath: null };
+  }
+  if (avatar.size > MAX_AVATAR_BYTES) {
+    return { error: "Photo must be 2MB or smaller" };
+  }
+  if (!ALLOWED_AVATAR_TYPES.has(avatar.type)) {
+    return { error: "Photo must be PNG or JPEG" };
+  }
+  const bytes = new Uint8Array(await avatar.arrayBuffer());
+  const key = `vehicle-avatars/${userId}/${createId()}`;
+  await getStorage().upload(key, bytes, avatar.type);
+  return { avatarPath: key };
+}
+
+/** Shared by the create and edit routes: parse the VehicleForm fields. */
+export function parseVehicleFields(data: FormData):
+  | { error: string }
+  | {
+      name: string | null;
+      make: string;
+      model: string;
+      trim: string | null;
+      year: number;
+      vin: string | null;
+      engine: string | null;
+    } {
+  const name = String(data.get("name") ?? "").trim() || null;
+  const make = String(data.get("make") ?? "").trim();
+  const model = String(data.get("model") ?? "").trim();
+  const trim = String(data.get("trim") ?? "").trim() || null;
+  const year = Number.parseInt(String(data.get("year") ?? "").trim(), 10);
+  const vin = String(data.get("vin") ?? "").trim() || null;
+  const engine = String(data.get("engine") ?? "").trim() || null;
+  if (!make || !model || !Number.isFinite(year)) {
+    return { error: "Make, model, and year are required" };
+  }
+  return { name, make, model, trim, year, vin, engine };
+}
 
 const createVehicleFn = createServerFn({ method: "POST" })
   .inputValidator((data: FormData) => data)
   .handler(async ({ data }) => {
     const userId = await requireAuth();
 
-    const name = String(data.get("name") ?? "").trim() || null;
-    const make = String(data.get("make") ?? "").trim();
-    const model = String(data.get("model") ?? "").trim();
-    const trim = String(data.get("trim") ?? "").trim() || null;
-    const yearRaw = String(data.get("year") ?? "").trim();
-    const year = Number.parseInt(yearRaw, 10);
+    const fields = parseVehicleFields(data);
+    if ("error" in fields) return { error: fields.error };
 
-    if (!make || !model || !Number.isFinite(year)) {
-      return { error: "Make, model, and year are required" as const };
-    }
-
-    let avatarPath: string | null = null;
-    const avatar = data.get("avatar");
-    if (avatar instanceof File && avatar.size > 0) {
-      if (avatar.size > MAX_AVATAR_BYTES) {
-        return { error: "Avatar must be 500KB or smaller" as const };
-      }
-      if (!ALLOWED_AVATAR_TYPES.has(avatar.type)) {
-        return { error: "Avatar must be PNG or JPEG" as const };
-      }
-      const bytes = new Uint8Array(await avatar.arrayBuffer());
-      const key = `vehicle-avatars/${userId}/${createId()}`;
-      await getStorage().upload(key, bytes, avatar.type);
-      avatarPath = key;
-    }
+    const stored = await storeAvatarUpload(data, userId);
+    if ("error" in stored) return { error: stored.error };
 
     const vehicle = await createVehicle({
       userId,
-      name,
-      make,
-      model,
-      trim,
-      year,
-      avatarPath,
+      ...fields,
+      vin: fields.vin ? fields.vin.toUpperCase() : null,
+      avatarPath: stored.avatarPath,
     });
 
     return { vehicleId: vehicle.id };
@@ -69,16 +89,14 @@ function NewVehiclePage() {
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
-  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
+  async function onSubmit(formData: FormData) {
     setError(null);
     setPending(true);
-    const formData = new FormData(e.currentTarget);
     try {
       const result = await createVehicleFn({ data: formData });
       if (result && "error" in result && result.error) {
         setError(result.error);
-      } else if (result && "vehicleId" in result) {
+      } else if (result && "vehicleId" in result && result.vehicleId) {
         navigate({
           to: "/vehicles/$vehicleId",
           params: { vehicleId: result.vehicleId },
@@ -94,45 +112,12 @@ function NewVehiclePage() {
   return (
     <section>
       <h1 className="text-2xl font-bold text-ink">Add vehicle</h1>
-      <form onSubmit={onSubmit} className="mt-6 max-w-lg space-y-4">
-        {error ? <p className={errorBox}>{error}</p> : null}
-        <Field name="name" label="Name (optional)" />
-        <Field name="make" label="Make" required />
-        <Field name="model" label="Model" required />
-        <Field name="trim" label="Trim (optional)" />
-        <Field name="year" label="Year" type="number" required />
-        <label className={labelClass}>
-          Photo (PNG or JPEG, ≤500KB, optional)
-          <input
-            name="avatar"
-            type="file"
-            accept="image/png,image/jpeg"
-            className="mt-1 block w-full text-sm text-ink"
-          />
-        </label>
-        <button type="submit" disabled={pending} className={btnPrimary}>
-          {pending ? "Saving…" : "Save"}
-        </button>
-      </form>
+      <VehicleForm
+        submitLabel="Save"
+        pending={pending}
+        error={error}
+        onSubmit={onSubmit}
+      />
     </section>
-  );
-}
-
-function Field({
-  name,
-  label,
-  type = "text",
-  required = false,
-}: {
-  name: string;
-  label: string;
-  type?: string;
-  required?: boolean;
-}) {
-  return (
-    <label className={labelClass}>
-      {label}
-      <input name={name} type={type} required={required} className={input} />
-    </label>
   );
 }

--- a/app/routes/_authed.vehicles.new.tsx
+++ b/app/routes/_authed.vehicles.new.tsx
@@ -1,4 +1,3 @@
-import { createId } from "@paralleldrive/cuid2";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { useState } from "react";
@@ -6,58 +5,10 @@ import { useState } from "react";
 import { requireAuth } from "~/auth/session.server";
 import { VehicleForm } from "~/components/VehicleForm";
 import { createVehicle } from "~/models/vehicle.server";
-import { getStorage } from "~/storage.server";
-
-// The client downscales to ~1024px JPEG first; this is just headroom for
-// the PNG-passthrough path and defense-in-depth.
-const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
-const ALLOWED_AVATAR_TYPES = new Set(["image/png", "image/jpeg"]);
-
-/** Shared by the create and edit routes: parse + store an avatar upload. */
-export async function storeAvatarUpload(
-  data: FormData,
-  userId: string,
-): Promise<{ error: string } | { avatarPath: string | null }> {
-  const avatar = data.get("avatar");
-  if (!(avatar instanceof File) || avatar.size === 0) {
-    return { avatarPath: null };
-  }
-  if (avatar.size > MAX_AVATAR_BYTES) {
-    return { error: "Photo must be 2MB or smaller" };
-  }
-  if (!ALLOWED_AVATAR_TYPES.has(avatar.type)) {
-    return { error: "Photo must be PNG or JPEG" };
-  }
-  const bytes = new Uint8Array(await avatar.arrayBuffer());
-  const key = `vehicle-avatars/${userId}/${createId()}`;
-  await getStorage().upload(key, bytes, avatar.type);
-  return { avatarPath: key };
-}
-
-/** Shared by the create and edit routes: parse the VehicleForm fields. */
-export function parseVehicleFields(data: FormData):
-  | { error: string }
-  | {
-      name: string | null;
-      make: string;
-      model: string;
-      trim: string | null;
-      year: number;
-      vin: string | null;
-      engine: string | null;
-    } {
-  const name = String(data.get("name") ?? "").trim() || null;
-  const make = String(data.get("make") ?? "").trim();
-  const model = String(data.get("model") ?? "").trim();
-  const trim = String(data.get("trim") ?? "").trim() || null;
-  const year = Number.parseInt(String(data.get("year") ?? "").trim(), 10);
-  const vin = String(data.get("vin") ?? "").trim() || null;
-  const engine = String(data.get("engine") ?? "").trim() || null;
-  if (!make || !model || !Number.isFinite(year)) {
-    return { error: "Make, model, and year are required" };
-  }
-  return { name, make, model, trim, year, vin, engine };
-}
+import {
+  parseVehicleFields,
+  storeAvatarUpload,
+} from "~/models/vehicle-form.server";
 
 const createVehicleFn = createServerFn({ method: "POST" })
   .inputValidator((data: FormData) => data)

--- a/app/routes/account.export.tsx
+++ b/app/routes/account.export.tsx
@@ -8,6 +8,7 @@ import {
   logsToParts,
   logsToTags,
   mechanics,
+  odometerReadings,
   parts,
   tags,
   users,
@@ -41,6 +42,7 @@ export const Route = createFileRoute("/account/export")({
         ]);
 
         const logIds = userLogs.map((l) => l.id);
+        const vehicleIds = userVehicles.map((v) => v.id);
         const mechanicIds = Array.from(
           new Set(
             userLogs
@@ -49,26 +51,33 @@ export const Route = createFileRoute("/account/export")({
           ),
         );
 
-        const [tagJoins, partJoins, mechanicRows] = await Promise.all([
-          logIds.length
-            ? db
-                .select()
-                .from(logsToTags)
-                .where(inArray(logsToTags.logId, logIds))
-            : Promise.resolve([]),
-          logIds.length
-            ? db
-                .select()
-                .from(logsToParts)
-                .where(inArray(logsToParts.logId, logIds))
-            : Promise.resolve([]),
-          mechanicIds.length
-            ? db
-                .select()
-                .from(mechanics)
-                .where(inArray(mechanics.id, mechanicIds))
-            : Promise.resolve([]),
-        ]);
+        const [tagJoins, partJoins, mechanicRows, readingRows] =
+          await Promise.all([
+            logIds.length
+              ? db
+                  .select()
+                  .from(logsToTags)
+                  .where(inArray(logsToTags.logId, logIds))
+              : Promise.resolve([]),
+            logIds.length
+              ? db
+                  .select()
+                  .from(logsToParts)
+                  .where(inArray(logsToParts.logId, logIds))
+              : Promise.resolve([]),
+            mechanicIds.length
+              ? db
+                  .select()
+                  .from(mechanics)
+                  .where(inArray(mechanics.id, mechanicIds))
+              : Promise.resolve([]),
+            vehicleIds.length
+              ? db
+                  .select()
+                  .from(odometerReadings)
+                  .where(inArray(odometerReadings.vehicleId, vehicleIds))
+              : Promise.resolve([]),
+          ]);
 
         const tagIds = Array.from(new Set(tagJoins.map((j) => j.tagId)));
         const partIds = Array.from(new Set(partJoins.map((j) => j.partId)));
@@ -91,6 +100,7 @@ export const Route = createFileRoute("/account/export")({
             avatarUrl: v.avatarPath ? `/files/${v.avatarPath}` : null,
           })),
           logs: userLogs,
+          odometerReadings: readingRows,
           mechanics: mechanicRows,
           tags: tagRows,
           parts: partRows,

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -149,4 +149,47 @@ test.describe("smoke tests", () => {
     // Verify empty state again
     await expect(page.getByText(/nothing logged yet/i)).toBeVisible();
   });
+
+  test("should allow editing a vehicle and adding an odometer reading", async ({
+    page,
+  }) => {
+    testEmail = generateTestEmail();
+
+    // Register + create a vehicle (same flow as the CRUD test).
+    await page.goto("/join");
+    await waitForHydration(page);
+    await page.getByLabel(/email/i).fill(testEmail);
+    await page.getByLabel(/password/i).fill(TEST_PASSWORD);
+    await page.getByRole("button", { name: /create account/i }).click();
+    await page.waitForURL("**/vehicles**");
+
+    await page.getByRole("link", { name: /add vehicle/i }).click();
+    await waitForHydration(page);
+    await page.getByLabel(/^year/i).fill("2024");
+    await page.getByLabel(/^make/i).fill("Jeep");
+    await page.getByLabel(/^model/i).fill("Wrangler");
+    await page.getByRole("button", { name: /^save$/i }).click();
+    await page.waitForURL("**/vehicles/**");
+    await expectNoErrors(page);
+
+    // Edit: rename + add an engine. Works offline from vPIC (free text).
+    await page.getByRole("link", { name: /edit vehicle/i }).click();
+    await waitForHydration(page);
+    await page.getByLabel(/name \(optional\)/i).fill("Rally Rig");
+    await page.getByLabel(/engine \(optional\)/i).fill("3.6L V6");
+    await page.getByRole("button", { name: /save changes/i }).click();
+    await expect(
+      page.getByRole("heading", { name: "Rally Rig" }),
+    ).toBeVisible();
+    await expect(page.getByText("3.6L V6")).toBeVisible();
+    await expectNoErrors(page);
+
+    // Odometer: chip → page → add a reading → both update.
+    await page.getByRole("link", { name: /last odometer/i }).click();
+    await waitForHydration(page);
+    await page.getByLabel(/miles/i).fill("42000");
+    await page.getByRole("button", { name: /add reading/i }).click();
+    await expect(page.getByText("42,000 mi").first()).toBeVisible();
+    await expectNoErrors(page);
+  });
 });


### PR DESCRIPTION
## What

**Odometer**
- New `odometer_readings` table — crew members can record a dash reading without creating a work log
- "Last odometer" is now the most recent reading by date across logs and manual readings (was max miles), shown with its date on the dashboard chip
- New `/vehicles/:id/odometer` page: current reading with source (linked service log or manual), quick-add form, full history; author-or-owner delete
- Reminders' due-miles math and the garage list use the same union latest
- `/account/export` bundle includes the readings

**Vehicle form**
- Owner-only edit page (name/make/model/trim/year/VIN/engine/photo) sharing a `VehicleForm` component with create
- New `vehicles.engine` column; engine + VIN shown in the vehicle header
- NHTSA vPIC VIN decode prefills year/make/model/trim/engine; make/model datalist suggestions (free API, browser-direct, degrades to plain free-text)
- Phone photos: client-side downscale (shared `app/lib/image.ts`, extracted from the scan page) — avatar cap raised to 2MB as headroom only

## Notes for review
- Semantics change: "current mileage" can now go *down* by deleting a typo'd reading — latest-by-date instead of max(miles). Reminder due-miles inherits this.
- `app/lib/image.ts` deliberately avoids the `.client.ts` suffix: route components are statically reachable from the SSR bundle and TanStack Start's import-protection denies `*.client.*` there; the functions are only called from browser event handlers.
- e2e: new smoke test passes; the pre-existing "create and delete a service log" test has a hydration race that reproduces on main (unrelated to this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)