### PR TITLE
fix(e2e): hydration race in the log CRUD smoke test

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,4 @@
 {
-  "enabledPlugins": {
-    "superpowers@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true
-  },
   "permissions": {
     "allow": [
       "Edit(/**)",
@@ -39,5 +35,8 @@
       "Bash(gh variable*)"
     ],
     "ask": ["Bash(yarn dlx *)", "Bash(rm -rf *)"]
+  },
+  "enabledPlugins": {
+    "pr-review-toolkit@claude-plugins-official": true
   }
 }

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -115,13 +115,16 @@ test.describe("smoke tests", () => {
 
     // Create vehicle
     await page.getByRole("link", { name: /add vehicle/i }).click();
+    await waitForHydration(page);
     await page.getByLabel(/make/i).fill(vehicleMake);
     await page.getByLabel(/model/i).fill(vehicleModel);
     await page.getByLabel(/year/i).fill(vehicleYear);
     await page.getByRole("button", { name: /save/i }).click();
 
-    // Verify redirect to the vehicle dashboard (no error flash)
-    await page.waitForURL("**/vehicles/**");
+    // Verify redirect to the vehicle dashboard (no error flash). The
+    // dashboard URL is /vehicles/<id> — exclude /vehicles/new so a failed
+    // submit that stays on the form can't satisfy this wait.
+    await page.waitForURL(/\/vehicles\/(?!new$)[^/]+$/);
     await expectNoErrors(page);
     await page.getByRole("link", { name: /^logs$/i }).click();
 
@@ -130,6 +133,7 @@ test.describe("smoke tests", () => {
 
     // Create log via quick capture
     await page.getByRole("link", { name: /log work/i }).click();
+    await waitForHydration(page);
     await page.getByLabel(/title/i).fill(logTitle);
     await page.getByLabel(/notes/i).fill(logNotes);
     await page.getByRole("button", { name: /save it/i }).click();


### PR DESCRIPTION
## What

Fixes the flaky "should allow you to create and delete a service log" smoke test (~1-in-3 failure locally, reproduces on main).

**Root cause** (confirmed via Playwright's failure snapshot): the test filled the create-vehicle form and clicked Save without waiting for hydration, so the click landed before React attached the JS submit handler — the same race the file's own `waitForHydration` comment describes for auth forms. The snapshot shows the browser still on the Add-vehicle form after Save. The failure then surfaced two steps later because `waitForURL("**/vehicles/**")` also matches `/vehicles/new`, silently masking the missed navigation.

**Fix**
- `waitForHydration(page)` after navigating to the create-vehicle form and the log-capture form (the pattern the passing tests already use)
- The dashboard `waitForURL` now excludes `/vehicles/new`, so a failed submit can't satisfy it — if this ever regresses, it fails at the right line

**Verification**: previously-flaky test passes 6/6 with `--repeat-each=6`; full e2e suite green.

Also includes a one-line `chore` commit dropping the superpowers plugin from the committed `.claude/settings.json` (no longer used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)