### PR TITLE
feat(documents): vehicle documents + purchase records with searchable scans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,12 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
    `vehicles.vin`: backfilled from receipts, never overwritten;
    `vehicles.engine`: free-text engine description, filled by vPIC decode,
    always user-editable;
+   `vehicles.purchasedAt`/`purchasePrice`/`purchaseOdometer`/`seller`/
+   `purchaseNote`: owner-editable acquisition details (Documents tab);
+   `vehicle_documents`: files attached directly to a vehicle (purchase
+   contract, title, registration, insurance), tagged by `kind` (vocab in
+   `document.shared.ts`), with `extracted_text` (best-effort OCR on image
+   upload) feeding a generated `search_tsv` GIN index for word-in-scan search;
    `logs.service_started_at` + `serviced_at`: service start and
    close/completion dates — a single-date receipt fills only the close;
    `odometer_readings`: standalone mileage entries (odometer, read_at, note,
@@ -143,6 +149,10 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
    client code can't import values from `.server.ts` modules),
    `attachment.server.ts` (log attachments — uploads via storage layer +
    row insert, access checked against the log's vehicle),
+   `document.server.ts` (vehicle documents — upload + best-effort OCR via
+   `transcribeImage`, FTS via `searchVehicleDocuments`, retag, uploader-or-
+   owner delete, blob reap on vehicle delete; kind vocab in
+   `document.shared.ts` because client routes can't import from `.server.ts`),
    `mechanic.server.ts` (vendors/shops — case-insensitive find-or-create;
    logs link via `logs.mechanicId`, the logs list filters by vendor),
    `odometer.server.ts` (union latest across logs + manual readings, batch
@@ -161,7 +171,9 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
 9. `app/scan/` — Scan Bay. `receipt.ts` is the isomorphic extraction
    contract (JSON schema + prompt + `normalizeReceipt`/`receiptToNotes`);
    `extract.server.ts` is the runtime seam (Workers AI binding on CF,
-   Ollama fallback on Node — `ollama.server.ts`); `import.server.ts` is
+   Ollama fallback on Node — `ollama.server.ts`; also exports
+   `transcribeImage`, the best-effort plain-text OCR that makes uploaded
+   vehicle documents searchable); `import.server.ts` is
    `createLogWithScan` (log + attachment + optional reminder), shared by
    the batch CLI (`scripts/scan-bay/`) and the in-app scan page.
 10. `app/routes/*` — file-based routes, including `/files/$` streaming
@@ -170,7 +182,11 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
     `_authed.vehicles.$vehicleId.odometer.tsx` (current reading + source +
     quick-add form + history with author-or-owner delete),
     `_authed.vehicles.$vehicleId.edit.tsx` (owner-only vehicle edit:
-    name/year/make/model/trim/engine/VIN/avatar), and `authorize.tsx`
+    name/year/make/model/trim/engine/VIN/avatar),
+    `_authed.vehicles.$vehicleId.documents.tsx` (Documents tab: owner-only
+    purchase-details panel + tagged document upload + FTS search box over
+    OCR'd text/label/filename + document list with retag and uploader-or-
+    owner delete), and `authorize.tsx`
     (OAuth consent for the MCP server — server handlers only, renders
     plain HTML, reuses session auth); `app/components/VehicleForm.tsx`
     is the shared create/edit form (vPIC assists + avatar downscale)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ What it does today:
   note) supplement work-log odometer readings. The dashboard chip shows the
   latest reading with its date; the odometer page lists the full history with
   source (linked service log or manual) and lets any crew member add a reading.
+- **Vehicle documents & purchase records** — a Documents tab on every
+  vehicle holds the paperwork: purchase contract, title, registration,
+  insurance, bill of sale. Upload images or PDFs, tag each by type, and
+  record structured purchase details (date, price, seller, odometer at
+  purchase). Uploaded photos are OCR'd locally on save, so you can
+  **search the words inside a scan** — find a policy number or VIN that
+  only appears in the image. Documents ship in the JSON export too.
 - **Crew sharing** — invite someone by email to any vehicle; members see
   and log everything on shared vehicles (invites for new emails are
   claimed automatically at signup).
@@ -338,6 +345,7 @@ out of the client bundle.
   "vehicles": [{ ..., "avatarUrl": "/files/..." }],
   "logs": [ ... ],
   "odometerReadings": [ ... ],
+  "vehicleDocuments": [{ ..., "fileUrl": "/files/..." }],
   "mechanics": [ ... ],
   "tags": [ ... ],
   "parts": [ ... ],

--- a/app/db/migrations/0007_swift_santa_claus.sql
+++ b/app/db/migrations/0007_swift_santa_claus.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "vehicle_documents" (
+	"id" text PRIMARY KEY NOT NULL,
+	"vehicle_id" text NOT NULL,
+	"path" text NOT NULL,
+	"content_type" text NOT NULL,
+	"original_name" text,
+	"kind" text DEFAULT 'other' NOT NULL,
+	"label" text,
+	"extracted_text" text,
+	"uploaded_by_id" text,
+	"search_tsv" "tsvector" GENERATED ALWAYS AS (to_tsvector('english', coalesce("vehicle_documents"."label", '') || ' ' || coalesce("vehicle_documents"."original_name", '') || ' ' || coalesce("vehicle_documents"."extracted_text", ''))) STORED,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "vehicles" ADD COLUMN "purchased_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "vehicles" ADD COLUMN "purchase_price" double precision;--> statement-breakpoint
+ALTER TABLE "vehicles" ADD COLUMN "purchase_odometer" double precision;--> statement-breakpoint
+ALTER TABLE "vehicles" ADD COLUMN "seller" text;--> statement-breakpoint
+ALTER TABLE "vehicles" ADD COLUMN "purchase_note" text;--> statement-breakpoint
+ALTER TABLE "vehicle_documents" ADD CONSTRAINT "vehicle_documents_vehicle_id_vehicles_id_fk" FOREIGN KEY ("vehicle_id") REFERENCES "public"."vehicles"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "vehicle_documents" ADD CONSTRAINT "vehicle_documents_uploaded_by_id_users_id_fk" FOREIGN KEY ("uploaded_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "vehicle_documents_vehicle_idx" ON "vehicle_documents" USING btree ("vehicle_id");--> statement-breakpoint
+CREATE INDEX "vehicle_documents_search_idx" ON "vehicle_documents" USING gin ("search_tsv");

--- a/app/db/migrations/meta/0007_snapshot.json
+++ b/app/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1657 @@
+{
+  "id": "7dfdf80d-4ce9-4b7d-b4fc-bd7e628d2e53",
+  "prevId": "8e55f2b7-6b90-4a13-9d49-9d5ec64c9f9c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.log_attachments": {
+      "name": "log_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "log_attachments_log_idx": {
+          "name": "log_attachments_log_idx",
+          "columns": [
+            {
+              "expression": "log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "log_attachments_log_id_logs_id_fk": {
+          "name": "log_attachments_log_id_logs_id_fk",
+          "tableFrom": "log_attachments",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_started_at": {
+          "name": "service_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serviced_at": {
+          "name": "serviced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "self_service": {
+          "name": "self_service",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mechanic_id": {
+          "name": "mechanic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(\"logs\".\"title\", '') || ' ' || coalesce(\"logs\".\"notes\", ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_search_idx": {
+          "name": "logs_search_idx",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "logs_vehicle_idx": {
+          "name": "logs_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_user_idx": {
+          "name": "logs_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "logs_user_id_users_id_fk": {
+          "name": "logs_user_id_users_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "logs_vehicle_id_vehicles_id_fk": {
+          "name": "logs_vehicle_id_vehicles_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "logs_mechanic_id_mechanics_id_fk": {
+          "name": "logs_mechanic_id_mechanics_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "mechanics",
+          "columnsFrom": [
+            "mechanic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_to_parts": {
+      "name": "logs_to_parts",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logs_to_parts_log_id_logs_id_fk": {
+          "name": "logs_to_parts_log_id_logs_id_fk",
+          "tableFrom": "logs_to_parts",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "logs_to_parts_part_id_parts_id_fk": {
+          "name": "logs_to_parts_part_id_parts_id_fk",
+          "tableFrom": "logs_to_parts",
+          "tableTo": "parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "logs_to_parts_log_id_part_id_pk": {
+          "name": "logs_to_parts_log_id_part_id_pk",
+          "columns": [
+            "log_id",
+            "part_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_to_tags": {
+      "name": "logs_to_tags",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logs_to_tags_log_id_logs_id_fk": {
+          "name": "logs_to_tags_log_id_logs_id_fk",
+          "tableFrom": "logs_to_tags",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "logs_to_tags_tag_id_tags_id_fk": {
+          "name": "logs_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "logs_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "logs_to_tags_log_id_tag_id_pk": {
+          "name": "logs_to_tags_log_id_tag_id_pk",
+          "columns": [
+            "log_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mechanics": {
+      "name": "mechanics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mechanics_email_idx": {
+          "name": "mechanics_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.odometer_readings": {
+      "name": "odometer_readings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "odometer_readings_vehicle_idx": {
+          "name": "odometer_readings_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "odometer_readings_user_id_users_id_fk": {
+          "name": "odometer_readings_user_id_users_id_fk",
+          "tableFrom": "odometer_readings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "odometer_readings_vehicle_id_vehicles_id_fk": {
+          "name": "odometer_readings_vehicle_id_vehicles_id_fk",
+          "tableFrom": "odometer_readings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parts": {
+      "name": "parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passwords": {
+      "name": "passwords",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passwords_user_id_users_id_fk": {
+          "name": "passwords_user_id_users_id_fk",
+          "tableFrom": "passwords",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passwords_user_id_unique": {
+          "name": "passwords_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_items": {
+      "name": "project_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_items_project_idx": {
+          "name": "project_items_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_items_project_id_projects_id_fk": {
+          "name": "project_items_project_id_projects_id_fk",
+          "tableFrom": "project_items",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idea'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_vehicle_idx": {
+          "name": "projects_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_vehicle_id_vehicles_id_fk": {
+          "name": "projects_vehicle_id_vehicles_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "projects_created_by_id_users_id_fk": {
+          "name": "projects_created_by_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reminders": {
+      "name": "reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_miles": {
+          "name": "due_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_months": {
+          "name": "interval_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_miles": {
+          "name": "interval_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reminders_vehicle_idx": {
+          "name": "reminders_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reminders_vehicle_id_vehicles_id_fk": {
+          "name": "reminders_vehicle_id_vehicles_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "reminders_created_by_id_users_id_fk": {
+          "name": "reminders_created_by_id_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_documents": {
+      "name": "vehicle_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(\"vehicle_documents\".\"label\", '') || ' ' || coalesce(\"vehicle_documents\".\"original_name\", '') || ' ' || coalesce(\"vehicle_documents\".\"extracted_text\", ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_documents_vehicle_idx": {
+          "name": "vehicle_documents_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vehicle_documents_search_idx": {
+          "name": "vehicle_documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_documents_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_documents_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_documents",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_documents_uploaded_by_id_users_id_fk": {
+          "name": "vehicle_documents_uploaded_by_id_users_id_fk",
+          "tableFrom": "vehicle_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_invites": {
+      "name": "vehicle_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_invites_vehicle_email_idx": {
+          "name": "vehicle_invites_vehicle_email_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vehicle_invites_email_idx": {
+          "name": "vehicle_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_invites_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_invites_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_invites",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_invites_invited_by_id_users_id_fk": {
+          "name": "vehicle_invites_invited_by_id_users_id_fk",
+          "tableFrom": "vehicle_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_members": {
+      "name": "vehicle_members",
+      "schema": "",
+      "columns": {
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_members_user_idx": {
+          "name": "vehicle_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_members_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_members_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_members",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_members_user_id_users_id_fk": {
+          "name": "vehicle_members_user_id_users_id_fk",
+          "tableFrom": "vehicle_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vehicle_members_vehicle_id_user_id_pk": {
+          "name": "vehicle_members_vehicle_id_user_id_pk",
+          "columns": [
+            "vehicle_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trim": {
+          "name": "trim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vin": {
+          "name": "vin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine": {
+          "name": "engine",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_odometer": {
+          "name": "purchase_odometer",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seller": {
+          "name": "seller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_note": {
+          "name": "purchase_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vehicles_user_id_users_id_fk": {
+          "name": "vehicles_user_id_users_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/db/migrations/meta/_journal.json
+++ b/app/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781236125214,
       "tag": "0006_noisy_firebrand",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1781472693558,
+      "tag": "0007_swift_santa_claus",
+      "breakpoints": true
     }
   ]
 }

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -76,6 +76,15 @@ export const vehicles = pgTable("vehicles", {
   // Free-text engine description, e.g. "3.6L V6 Pentastar". Filled by the
   // vPIC VIN decode on the vehicle form, always user-editable.
   engine: text(),
+  // Acquisition details. `purchasedAt` is date-only (UTC midnight from an
+  // <input type="date">) — render with formatDateOnly. `seller` is the
+  // dealer or private party. Owner-editable on the Documents tab; the actual
+  // contract / title scans live in `vehicle_documents`.
+  purchasedAt: timestamp("purchased_at", { withTimezone: true, mode: "date" }),
+  purchasePrice: doublePrecision("purchase_price"),
+  purchaseOdometer: doublePrecision("purchase_odometer"),
+  seller: text(),
+  purchaseNote: text("purchase_note"),
   avatarPath: text("avatar_path"),
   userId: text("user_id")
     .notNull()
@@ -274,6 +283,45 @@ export const logAttachments = pgTable(
   (t) => [index("log_attachments_log_idx").on(t.logId)],
 );
 
+// Documents attached directly to a vehicle (not a service log): the purchase
+// contract, title, registration, insurance card, bill of sale. `kind` tags
+// the document (vocab in document.shared.ts); `extractedText` is OCR pulled
+// from image uploads (best-effort, see transcribeImage) and feeds the
+// generated `search_tsv` GIN index so crew can search words inside scans.
+export const vehicleDocuments = pgTable(
+  "vehicle_documents",
+  {
+    id: cuid2().primaryKey(),
+    vehicleId: text("vehicle_id")
+      .notNull()
+      .references(() => vehicles.id, {
+        onDelete: "cascade",
+        onUpdate: "cascade",
+      }),
+    path: text().notNull(),
+    contentType: text("content_type").notNull(),
+    originalName: text("original_name"),
+    kind: text().notNull().default("other"),
+    // Optional human label, e.g. "2024 registration renewal".
+    label: text(),
+    // OCR transcription of an image document, filled on upload when a vision
+    // backend is reachable. Null for PDFs and when transcription is skipped.
+    extractedText: text("extracted_text"),
+    uploadedById: text("uploaded_by_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    searchTsv: tsvector("search_tsv").generatedAlwaysAs(
+      (): SQL =>
+        sql`to_tsvector('english', coalesce(${vehicleDocuments.label}, '') || ' ' || coalesce(${vehicleDocuments.originalName}, '') || ' ' || coalesce(${vehicleDocuments.extractedText}, ''))`,
+    ),
+    ...timestamps,
+  },
+  (t) => [
+    index("vehicle_documents_vehicle_idx").on(t.vehicleId),
+    index("vehicle_documents_search_idx").using("gin", t.searchTsv),
+  ],
+);
+
 export const tags = pgTable(
   "tags",
   {
@@ -362,5 +410,7 @@ export type ProjectItem = typeof projectItems.$inferSelect;
 export type NewProjectItem = typeof projectItems.$inferInsert;
 export type LogAttachment = typeof logAttachments.$inferSelect;
 export type NewLogAttachment = typeof logAttachments.$inferInsert;
+export type VehicleDocument = typeof vehicleDocuments.$inferSelect;
+export type NewVehicleDocument = typeof vehicleDocuments.$inferInsert;
 export type OdometerReading = typeof odometerReadings.$inferSelect;
 export type NewOdometerReading = typeof odometerReadings.$inferInsert;

--- a/app/models/document.server.test.ts
+++ b/app/models/document.server.test.ts
@@ -1,0 +1,257 @@
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createDb } from "~/db/client";
+import { users, vehicleMembers } from "~/db/schema";
+import {
+  addVehicleDocument,
+  deleteDocumentBlobsForVehicles,
+  listVehicleDocuments,
+  removeVehicleDocument,
+  searchVehicleDocuments,
+  updateVehicleDocument,
+} from "~/models/document.server";
+import { createVehicle, deleteVehicle } from "~/models/vehicle.server";
+import type { Storage, StoredFile } from "~/storage.server";
+
+// Integration test — requires DATABASE_URL pointing at a running local Postgres
+// with migrations applied. Storage is stubbed so we don't touch the filesystem.
+// Documents are uploaded as PDFs so the (best-effort, backend-dependent) OCR
+// path is skipped and the test stays hermetic.
+
+const url = process.env.DATABASE_URL;
+if (!url) throw new Error("DATABASE_URL is required for document test");
+
+const { db, close } = createDb(url);
+
+/** In-memory Storage so the test never hits disk or R2. */
+class MemoryStorage implements Storage {
+  readonly files = new Map<string, StoredFile>();
+  async upload(
+    key: string,
+    body: Uint8Array | ArrayBuffer,
+    contentType: string,
+  ) {
+    const bytes = body instanceof Uint8Array ? body : new Uint8Array(body);
+    this.files.set(key, { body: bytes, contentType });
+  }
+  async read(key: string) {
+    return this.files.get(key) ?? null;
+  }
+  async exists(key: string) {
+    return this.files.has(key);
+  }
+  async delete(key: string) {
+    this.files.delete(key);
+  }
+}
+
+const stamp = Date.now();
+let ownerId: string;
+let memberId: string;
+let vehicleId: string;
+
+beforeAll(async () => {
+  const [owner] = await db
+    .insert(users)
+    .values({ email: `doc-owner-${stamp}@example.com` })
+    .returning();
+  const [member] = await db
+    .insert(users)
+    .values({ email: `doc-member-${stamp}@example.com` })
+    .returning();
+  if (!owner || !member) throw new Error("user insert failed");
+  ownerId = owner.id;
+  memberId = member.id;
+
+  const vehicle = await createVehicle({
+    userId: ownerId,
+    make: "Test",
+    model: "Vehicle",
+    year: 2020,
+  });
+  vehicleId = vehicle.id;
+
+  await db
+    .insert(vehicleMembers)
+    .values({ vehicleId, userId: memberId, role: "member" });
+});
+
+afterAll(async () => {
+  await db.delete(users).where(eq(users.id, ownerId));
+  await db.delete(users).where(eq(users.id, memberId));
+  await close();
+});
+
+describe("vehicle documents", () => {
+  it("stores bytes, records the row, and tags the uploader", async () => {
+    const storage = new MemoryStorage();
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+
+    const doc = await addVehicleDocument({
+      vehicleId,
+      userId: ownerId,
+      body: bytes,
+      contentType: "application/pdf",
+      originalName: "Purchase Contract.pdf",
+      kind: "purchase",
+      label: "Bought from Bay Area Jeep",
+      storage,
+    });
+
+    expect(doc.vehicleId).toBe(vehicleId);
+    expect(doc.kind).toBe("purchase");
+    expect(doc.uploadedById).toBe(ownerId);
+    expect(doc.path.startsWith(`vehicle-documents/${vehicleId}/`)).toBe(true);
+    expect(doc.path).toContain("purchase-contract.pdf");
+    expect(storage.files.get(doc.path)?.body).toEqual(bytes);
+
+    const list = await listVehicleDocuments({ vehicleId, userId: memberId });
+    expect(list.map((d) => d.id)).toContain(doc.id);
+  });
+
+  it("coerces an unknown kind to 'other'", async () => {
+    const doc = await addVehicleDocument({
+      vehicleId,
+      userId: ownerId,
+      body: new Uint8Array([5]),
+      contentType: "application/pdf",
+      kind: "not-a-real-kind",
+      storage: new MemoryStorage(),
+    });
+    expect(doc.kind).toBe("other");
+  });
+
+  it("full-text searches over the label", async () => {
+    await addVehicleDocument({
+      vehicleId,
+      userId: ownerId,
+      body: new Uint8Array([7]),
+      contentType: "application/pdf",
+      kind: "registration",
+      label: "2024 registration renewal sticker",
+      storage: new MemoryStorage(),
+    });
+
+    const hits = await searchVehicleDocuments({
+      vehicleId,
+      userId: memberId,
+      query: "renewal",
+    });
+    expect(hits.some((d) => d.label?.includes("renewal"))).toBe(true);
+
+    const misses = await searchVehicleDocuments({
+      vehicleId,
+      userId: memberId,
+      query: "transmission",
+    });
+    expect(misses.some((d) => d.label?.includes("renewal"))).toBe(false);
+  });
+
+  it("retags a document", async () => {
+    const doc = await addVehicleDocument({
+      vehicleId,
+      userId: ownerId,
+      body: new Uint8Array([8]),
+      contentType: "application/pdf",
+      kind: "other",
+      storage: new MemoryStorage(),
+    });
+    const updated = await updateVehicleDocument({
+      id: doc.id,
+      vehicleId,
+      userId: memberId,
+      kind: "title",
+    });
+    expect(updated?.kind).toBe("title");
+  });
+
+  it("rejects access from a user without crew membership", async () => {
+    const [stranger] = await db
+      .insert(users)
+      .values({ email: `doc-stranger-${stamp}@example.com` })
+      .returning();
+    if (!stranger) throw new Error("stranger insert failed");
+    try {
+      await expect(
+        listVehicleDocuments({ vehicleId, userId: stranger.id }),
+      ).rejects.toThrow("Vehicle not found");
+    } finally {
+      await db.delete(users).where(eq(users.id, stranger.id));
+    }
+  });
+
+  it("lets the uploader delete, removing the row and the bytes", async () => {
+    const storage = new MemoryStorage();
+    const doc = await addVehicleDocument({
+      vehicleId,
+      userId: memberId,
+      body: new Uint8Array([9, 9]),
+      contentType: "application/pdf",
+      storage,
+    });
+    const deleted = await removeVehicleDocument({
+      id: doc.id,
+      vehicleId,
+      userId: memberId,
+      storage,
+    });
+    expect(deleted?.id).toBe(doc.id);
+    expect(storage.files.has(doc.path)).toBe(false);
+  });
+
+  it("blocks a non-uploader member from deleting, but lets the owner", async () => {
+    const storage = new MemoryStorage();
+    const doc = await addVehicleDocument({
+      vehicleId,
+      userId: ownerId,
+      body: new Uint8Array([1]),
+      contentType: "application/pdf",
+      storage,
+    });
+
+    await expect(
+      removeVehicleDocument({
+        id: doc.id,
+        vehicleId,
+        userId: memberId,
+        storage,
+      }),
+    ).rejects.toThrow("Only the uploader or the owner");
+
+    const deleted = await removeVehicleDocument({
+      id: doc.id,
+      vehicleId,
+      userId: ownerId,
+      storage,
+    });
+    expect(deleted?.id).toBe(doc.id);
+  });
+
+  it("reaps document blobs when the vehicle is deleted", async () => {
+    const storage = new MemoryStorage();
+    const throwaway = await createVehicle({
+      userId: ownerId,
+      make: "Throw",
+      model: "Away",
+      year: 2021,
+    });
+    const doc = await addVehicleDocument({
+      vehicleId: throwaway.id,
+      userId: ownerId,
+      body: new Uint8Array([3, 3, 3]),
+      contentType: "application/pdf",
+      storage,
+    });
+    expect(storage.files.has(doc.path)).toBe(true);
+
+    await deleteVehicle({ id: throwaway.id, userId: ownerId, storage });
+    expect(storage.files.has(doc.path)).toBe(false);
+  });
+
+  it("deleteDocumentBlobsForVehicles is a no-op for an empty list", async () => {
+    await expect(
+      deleteDocumentBlobsForVehicles({ vehicleIds: [] }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/app/models/document.server.ts
+++ b/app/models/document.server.ts
@@ -1,0 +1,221 @@
+import { createId } from "@paralleldrive/cuid2";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
+
+import { getDb } from "~/db/client";
+import type { VehicleDocument } from "~/db/schema";
+import { users, vehicleDocuments } from "~/db/schema";
+import { normalizeDocumentKind } from "~/models/document.shared";
+import { requireVehicleAccess, type VehicleRole } from "~/models/member.server";
+import { transcribeImage } from "~/scan/extract.server";
+import { getStorage, type Storage } from "~/storage.server";
+
+export type { VehicleDocument };
+
+export type VehicleDocumentListItem = VehicleDocument & {
+  uploaderName: string | null;
+};
+
+/** Strip a filename to a storage-key-safe slug, preserving the extension. */
+function safeName(name: string | null | undefined): string {
+  if (!name) return "document";
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9.]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug.slice(0, 80) : "document";
+}
+
+const uploaderName = sql<
+  string | null
+>`coalesce(${users.displayName}, ${users.email})`;
+
+/** All documents on a vehicle, newest first. Any crew member can view. */
+export async function listVehicleDocuments({
+  vehicleId,
+  userId,
+}: {
+  vehicleId: string;
+  userId: string;
+}): Promise<VehicleDocumentListItem[]> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const rows = await db
+    .select({ doc: vehicleDocuments, uploaderName })
+    .from(vehicleDocuments)
+    .leftJoin(users, eq(users.id, vehicleDocuments.uploadedById))
+    .where(eq(vehicleDocuments.vehicleId, vehicleId))
+    .orderBy(desc(vehicleDocuments.createdAt));
+  return rows.map((r) => ({ ...r.doc, uploaderName: r.uploaderName }));
+}
+
+/**
+ * Full-text search over a vehicle's documents — matches the generated
+ * `search_tsv` (label + filename + OCR'd text) GIN index, so a word that
+ * only appears inside a scanned image still hits.
+ */
+export async function searchVehicleDocuments({
+  vehicleId,
+  userId,
+  query,
+}: {
+  vehicleId: string;
+  userId: string;
+  query: string;
+}): Promise<VehicleDocumentListItem[]> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const trimmed = query.trim();
+  if (!trimmed) return listVehicleDocuments({ vehicleId, userId });
+  const db = await getDb();
+  const rows = await db
+    .select({ doc: vehicleDocuments, uploaderName })
+    .from(vehicleDocuments)
+    .leftJoin(users, eq(users.id, vehicleDocuments.uploadedById))
+    .where(
+      and(
+        eq(vehicleDocuments.vehicleId, vehicleId),
+        sql`${vehicleDocuments.searchTsv} @@ websearch_to_tsquery('english', ${trimmed})`,
+      ),
+    )
+    .orderBy(desc(vehicleDocuments.createdAt));
+  return rows.map((r) => ({ ...r.doc, uploaderName: r.uploaderName }));
+}
+
+/**
+ * Store a document on a vehicle and (for images) OCR it for search. Any crew
+ * member may add. OCR is best-effort — a transcription failure never blocks
+ * the upload; the document is still stored and searchable by label/filename.
+ */
+export async function addVehicleDocument({
+  vehicleId,
+  userId,
+  body,
+  contentType,
+  originalName,
+  kind,
+  label,
+  storage = getStorage(),
+}: {
+  vehicleId: string;
+  userId: string;
+  body: Uint8Array;
+  contentType: string;
+  originalName?: string | null;
+  kind?: string | null;
+  label?: string | null;
+  storage?: Storage;
+}): Promise<VehicleDocument> {
+  await requireVehicleAccess({ vehicleId, userId });
+
+  const key = `vehicle-documents/${vehicleId}/${createId()}-${safeName(originalName)}`;
+  await storage.upload(key, body, contentType);
+
+  let extractedText: string | null = null;
+  if (contentType.startsWith("image/")) {
+    extractedText = await transcribeImage(body, contentType);
+  }
+
+  const db = await getDb();
+  const [doc] = await db
+    .insert(vehicleDocuments)
+    .values({
+      vehicleId,
+      path: key,
+      contentType,
+      originalName: originalName ?? null,
+      kind: normalizeDocumentKind(kind),
+      label: label?.trim() || null,
+      extractedText,
+      uploadedById: userId,
+    })
+    .returning();
+  if (!doc) throw new Error("Failed to save document");
+  return doc;
+}
+
+/** Edit a document's tag/label without re-uploading. Any crew member. */
+export async function updateVehicleDocument({
+  id,
+  vehicleId,
+  userId,
+  kind,
+  label,
+}: {
+  id: string;
+  vehicleId: string;
+  userId: string;
+  kind?: string | null;
+  label?: string | null;
+}): Promise<VehicleDocument | null> {
+  await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const [updated] = await db
+    .update(vehicleDocuments)
+    .set({
+      ...(kind !== undefined ? { kind: normalizeDocumentKind(kind) } : {}),
+      ...(label !== undefined ? { label: label?.trim() || null } : {}),
+    })
+    .where(
+      and(
+        eq(vehicleDocuments.id, id),
+        eq(vehicleDocuments.vehicleId, vehicleId),
+      ),
+    )
+    .returning();
+  return updated ?? null;
+}
+
+/**
+ * Delete a document — the row and the stored bytes. The uploader or the
+ * vehicle owner may delete (same rule as manual odometer readings).
+ */
+export async function removeVehicleDocument({
+  id,
+  vehicleId,
+  userId,
+  storage = getStorage(),
+}: {
+  id: string;
+  vehicleId: string;
+  userId: string;
+  storage?: Storage;
+}): Promise<VehicleDocument | null> {
+  const role: VehicleRole = await requireVehicleAccess({ vehicleId, userId });
+  const db = await getDb();
+  const [doc] = await db
+    .select()
+    .from(vehicleDocuments)
+    .where(
+      and(
+        eq(vehicleDocuments.id, id),
+        eq(vehicleDocuments.vehicleId, vehicleId),
+      ),
+    );
+  if (!doc) return null;
+  if (doc.uploadedById !== userId && role !== "owner") {
+    throw new Error("Only the uploader or the owner can delete a document");
+  }
+  await db.delete(vehicleDocuments).where(eq(vehicleDocuments.id, id));
+  await storage.delete(doc.path);
+  return doc;
+}
+
+/**
+ * Blob cleanup for cascading vehicle deletes: remove the stored bytes for
+ * every document on the given vehicles. The rows themselves cascade via the
+ * FK; this only reaps storage. Access must already be checked by the caller.
+ */
+export async function deleteDocumentBlobsForVehicles({
+  vehicleIds,
+  storage = getStorage(),
+}: {
+  vehicleIds: string[];
+  storage?: Storage;
+}): Promise<void> {
+  if (vehicleIds.length === 0) return;
+  const db = await getDb();
+  const rows = await db
+    .select({ path: vehicleDocuments.path })
+    .from(vehicleDocuments)
+    .where(inArray(vehicleDocuments.vehicleId, vehicleIds));
+  await Promise.all(rows.map((row) => storage.delete(row.path)));
+}

--- a/app/models/document.shared.ts
+++ b/app/models/document.shared.ts
@@ -1,0 +1,42 @@
+/**
+ * Vehicle-document kind vocabulary. Lives in a `.shared.ts` (not the
+ * `.server.ts` model) because route components need the labels/list and
+ * client code can't import values from server-only modules.
+ */
+
+export const DOCUMENT_KINDS = [
+  "purchase",
+  "title",
+  "registration",
+  "insurance",
+  "bill_of_sale",
+  "warranty",
+  "other",
+] as const;
+
+export type DocumentKind = (typeof DOCUMENT_KINDS)[number];
+
+export const DOCUMENT_KIND_LABELS: Record<DocumentKind, string> = {
+  purchase: "Purchase / contract",
+  title: "Title",
+  registration: "Registration",
+  insurance: "Insurance",
+  bill_of_sale: "Bill of sale",
+  warranty: "Warranty",
+  other: "Other",
+};
+
+export function documentKindLabel(kind: string): string {
+  return (
+    DOCUMENT_KIND_LABELS[kind as DocumentKind] ?? DOCUMENT_KIND_LABELS.other
+  );
+}
+
+/** Coerce arbitrary input (form value, import) to a known kind. */
+export function normalizeDocumentKind(
+  kind: string | null | undefined,
+): DocumentKind {
+  return DOCUMENT_KINDS.includes(kind as DocumentKind)
+    ? (kind as DocumentKind)
+    : "other";
+}

--- a/app/models/vehicle.server.ts
+++ b/app/models/vehicle.server.ts
@@ -4,6 +4,7 @@ import { getDb } from "~/db/client";
 import type { NewVehicle, Vehicle } from "~/db/schema";
 import { logs, reminders, vehicleMembers, vehicles } from "~/db/schema";
 import { deleteAttachmentBlobsForLogs } from "~/models/attachment.server";
+import { deleteDocumentBlobsForVehicles } from "~/models/document.server";
 import {
   requireVehicleAccess,
   requireVehicleOwner,
@@ -205,6 +206,45 @@ export async function updateVehicle({
   return updated;
 }
 
+/**
+ * Owner-only edit of the vehicle's acquisition details. Mirrors the
+ * owner-only `updateVehicle` (these fields sit alongside VIN/engine on the
+ * vehicle row). Members see the details read-only on the Documents tab.
+ */
+export async function updatePurchase({
+  id,
+  userId,
+  purchasedAt,
+  purchasePrice,
+  purchaseOdometer,
+  seller,
+  purchaseNote,
+}: {
+  id: string;
+  userId: string;
+  purchasedAt: Date | null;
+  purchasePrice: number | null;
+  purchaseOdometer: number | null;
+  seller: string | null;
+  purchaseNote: string | null;
+}): Promise<Vehicle> {
+  await requireVehicleOwner({ vehicleId: id, userId });
+  const db = await getDb();
+  const [updated] = await db
+    .update(vehicles)
+    .set({
+      purchasedAt,
+      purchasePrice,
+      purchaseOdometer,
+      seller: seller?.trim() || null,
+      purchaseNote: purchaseNote?.trim() || null,
+    })
+    .where(eq(vehicles.id, id))
+    .returning();
+  if (!updated) throw new Error("Failed to update purchase details");
+  return updated;
+}
+
 /** Owner only — `userId` must match the vehicle's owner column. */
 export async function deleteVehicle({
   id,
@@ -230,6 +270,18 @@ export async function deleteVehicle({
     logIds: logRows.map((r) => r.id),
     ...(storage ? { storage } : {}),
   });
+  // Reap vehicle-document bytes too — only when this user owns the vehicle,
+  // matching the scoped delete below (a non-owner gets a no-op either way).
+  const owned = await db
+    .select({ id: vehicles.id })
+    .from(vehicles)
+    .where(and(eq(vehicles.id, id), eq(vehicles.userId, userId)));
+  if (owned.length > 0) {
+    await deleteDocumentBlobsForVehicles({
+      vehicleIds: [id],
+      ...(storage ? { storage } : {}),
+    });
+  }
   return db
     .delete(vehicles)
     .where(and(eq(vehicles.id, id), eq(vehicles.userId, userId)));

--- a/app/routes/_authed.vehicles.$vehicleId.documents.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.documents.tsx
@@ -1,0 +1,552 @@
+import {
+  createFileRoute,
+  getRouteApi,
+  useRouter,
+} from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { useRef, useState } from "react";
+
+import { requireAuth } from "~/auth/session.server";
+import { formatDateOnly } from "~/components/format";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  errorBox,
+  input,
+  label as labelClass,
+} from "~/components/ui";
+import {
+  addVehicleDocument,
+  listVehicleDocuments,
+  removeVehicleDocument,
+  searchVehicleDocuments,
+  updateVehicleDocument,
+} from "~/models/document.server";
+import { DOCUMENT_KINDS, documentKindLabel } from "~/models/document.shared";
+import { updatePurchase } from "~/models/vehicle.server";
+
+const parentApi = getRouteApi("/_authed/vehicles/$vehicleId");
+
+const MAX_DOCUMENT_BYTES = 12 * 1024 * 1024;
+
+const loadDocumentsFn = createServerFn({ method: "GET" })
+  .inputValidator((data: { vehicleId: string; q: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    const documents = data.q.trim()
+      ? await searchVehicleDocuments({
+          vehicleId: data.vehicleId,
+          userId,
+          query: data.q,
+        })
+      : await listVehicleDocuments({ vehicleId: data.vehicleId, userId });
+    return { documents, userId };
+  });
+
+const savePurchaseFn = createServerFn({ method: "POST" })
+  .inputValidator(
+    (data: {
+      vehicleId: string;
+      purchasedAt: string;
+      purchasePrice: string;
+      purchaseOdometer: string;
+      seller: string;
+      purchaseNote: string;
+    }) => data,
+  )
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    try {
+      const purchasedAt = data.purchasedAt ? new Date(data.purchasedAt) : null;
+      const price = Number.parseFloat(data.purchasePrice);
+      const odometer = Number.parseFloat(data.purchaseOdometer);
+      await updatePurchase({
+        id: data.vehicleId,
+        userId,
+        purchasedAt:
+          purchasedAt && !Number.isNaN(purchasedAt.getTime())
+            ? purchasedAt
+            : null,
+        purchasePrice: Number.isFinite(price) ? price : null,
+        purchaseOdometer: Number.isFinite(odometer) ? odometer : null,
+        seller: data.seller || null,
+        purchaseNote: data.purchaseNote || null,
+      });
+      return {};
+    } catch (err) {
+      return {
+        error: err instanceof Error ? err.message : "Failed to save details",
+      };
+    }
+  });
+
+const uploadDocumentFn = createServerFn({ method: "POST" })
+  .inputValidator((data: FormData) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    const vehicleId = String(data.get("vehicleId") ?? "");
+    if (!vehicleId) return { error: "Missing vehicle" };
+    const kind = String(data.get("kind") ?? "other");
+    const label = String(data.get("label") ?? "");
+
+    const files = data
+      .getAll("files")
+      .filter((f): f is File => f instanceof File && f.size > 0);
+    if (files.length === 0) return { error: "No files selected" };
+    for (const file of files) {
+      if (file.size > MAX_DOCUMENT_BYTES) {
+        return { error: `${file.name} is too large (12 MB max)` };
+      }
+      if (!file.type.startsWith("image/") && file.type !== "application/pdf") {
+        return { error: `${file.name}: only images and PDFs` };
+      }
+    }
+
+    for (const file of files) {
+      await addVehicleDocument({
+        vehicleId,
+        userId,
+        body: new Uint8Array(await file.arrayBuffer()),
+        contentType: file.type,
+        originalName: file.name,
+        kind,
+        label,
+      });
+    }
+    return { count: files.length };
+  });
+
+const retagDocumentFn = createServerFn({ method: "POST" })
+  .inputValidator(
+    (data: { vehicleId: string; id: string; kind: string }) => data,
+  )
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await updateVehicleDocument({
+      id: data.id,
+      vehicleId: data.vehicleId,
+      userId,
+      kind: data.kind,
+    });
+  });
+
+const deleteDocumentFn = createServerFn({ method: "POST" })
+  .inputValidator((data: { vehicleId: string; id: string }) => data)
+  .handler(async ({ data }) => {
+    const userId = await requireAuth();
+    await removeVehicleDocument({
+      id: data.id,
+      vehicleId: data.vehicleId,
+      userId,
+    });
+  });
+
+export const Route = createFileRoute("/_authed/vehicles/$vehicleId/documents")({
+  component: DocumentsPage,
+  validateSearch: (search: Record<string, unknown>) => ({
+    q: typeof search.q === "string" ? search.q : "",
+  }),
+  loaderDeps: ({ search }) => ({ q: search.q }),
+  loader: async ({ params, deps }) =>
+    loadDocumentsFn({ data: { vehicleId: params.vehicleId, q: deps.q } }),
+});
+
+/** A Date or null as a YYYY-MM-DD value for <input type="date">. */
+function dateInputValue(d: Date | null): string {
+  return d ? new Date(d).toISOString().slice(0, 10) : "";
+}
+
+function PurchasePanel({
+  vehicleId,
+  isOwner,
+}: {
+  vehicleId: string;
+  isOwner: boolean;
+}) {
+  const router = useRouter();
+  const v = parentApi.useLoaderData();
+  const [editing, setEditing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const hasDetails =
+    v.purchasedAt != null ||
+    v.purchasePrice != null ||
+    v.purchaseOdometer != null ||
+    v.seller != null ||
+    v.purchaseNote != null;
+
+  async function onSave(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setPending(true);
+    const fd = new FormData(e.currentTarget);
+    try {
+      const result = await savePurchaseFn({
+        data: {
+          vehicleId,
+          purchasedAt: String(fd.get("purchasedAt") ?? ""),
+          purchasePrice: String(fd.get("purchasePrice") ?? ""),
+          purchaseOdometer: String(fd.get("purchaseOdometer") ?? ""),
+          seller: String(fd.get("seller") ?? "").trim(),
+          purchaseNote: String(fd.get("purchaseNote") ?? "").trim(),
+        },
+      });
+      if (result && "error" in result && result.error) {
+        setError(result.error);
+        return;
+      }
+      setEditing(false);
+      await router.invalidate();
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <section className={`${card} p-5`}>
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-bold text-ink">Purchase details</h2>
+        {isOwner && !editing ? (
+          <button
+            type="button"
+            className="text-sm font-semibold text-accent hover:underline"
+            onClick={() => setEditing(true)}
+          >
+            {hasDetails ? "Edit" : "Add"}
+          </button>
+        ) : null}
+      </div>
+
+      {editing ? (
+        <form onSubmit={onSave} className="mt-3 space-y-3">
+          {error ? <p className={errorBox}>{error}</p> : null}
+          <div className="grid grid-cols-2 gap-3">
+            <label className={labelClass}>
+              Purchase date
+              <input
+                type="date"
+                name="purchasedAt"
+                defaultValue={dateInputValue(v.purchasedAt)}
+                className={input}
+              />
+            </label>
+            <label className={labelClass}>
+              Price ($)
+              <input
+                type="number"
+                name="purchasePrice"
+                step="0.01"
+                min="0"
+                inputMode="decimal"
+                defaultValue={v.purchasePrice ?? ""}
+                className={`${input} tabular-nums`}
+              />
+            </label>
+            <label className={labelClass}>
+              Odometer at purchase
+              <input
+                type="number"
+                name="purchaseOdometer"
+                step="1"
+                min="0"
+                inputMode="numeric"
+                defaultValue={v.purchaseOdometer ?? ""}
+                className={`${input} tabular-nums`}
+              />
+            </label>
+            <label className={labelClass}>
+              Seller
+              <input
+                name="seller"
+                defaultValue={v.seller ?? ""}
+                placeholder="Dealer or private party"
+                className={input}
+              />
+            </label>
+          </div>
+          <label className={labelClass}>
+            Note (optional)
+            <input
+              name="purchaseNote"
+              defaultValue={v.purchaseNote ?? ""}
+              placeholder="Out-the-door price included new tires"
+              className={input}
+            />
+          </label>
+          <div className="flex gap-2">
+            <button type="submit" disabled={pending} className={btnPrimary}>
+              {pending ? "Saving…" : "Save"}
+            </button>
+            <button
+              type="button"
+              className={btnSecondary}
+              onClick={() => {
+                setEditing(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : hasDetails ? (
+        <dl className="mt-3 grid grid-cols-2 gap-3 text-sm">
+          {v.purchasedAt != null ? (
+            <div>
+              <dt className="text-ink-muted">Purchased</dt>
+              <dd className="font-semibold text-ink">
+                {formatDateOnly(v.purchasedAt)}
+              </dd>
+            </div>
+          ) : null}
+          {v.purchasePrice != null ? (
+            <div>
+              <dt className="text-ink-muted">Price</dt>
+              <dd className="font-semibold tabular-nums text-ink">
+                ${v.purchasePrice.toLocaleString()}
+              </dd>
+            </div>
+          ) : null}
+          {v.purchaseOdometer != null ? (
+            <div>
+              <dt className="text-ink-muted">Odometer at purchase</dt>
+              <dd className="font-semibold tabular-nums text-ink">
+                {Math.round(v.purchaseOdometer).toLocaleString()} mi
+              </dd>
+            </div>
+          ) : null}
+          {v.seller != null ? (
+            <div>
+              <dt className="text-ink-muted">Seller</dt>
+              <dd className="font-semibold text-ink">{v.seller}</dd>
+            </div>
+          ) : null}
+          {v.purchaseNote != null ? (
+            <div className="col-span-2">
+              <dt className="text-ink-muted">Note</dt>
+              <dd className="text-ink">{v.purchaseNote}</dd>
+            </div>
+          ) : null}
+        </dl>
+      ) : (
+        <p className="mt-2 text-sm text-ink-muted">
+          {isOwner
+            ? "Record when and where you bought this vehicle, the price, and the odometer at purchase."
+            : "No purchase details recorded yet."}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function DocumentsPage() {
+  const router = useRouter();
+  const v = parentApi.useLoaderData();
+  const { documents, userId } = Route.useLoaderData();
+  const { q } = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const isOwner = v.role === "owner";
+
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [kind, setKind] = useState<string>("purchase");
+  const [docLabel, setDocLabel] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState(q);
+
+  async function onUpload(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const picked = fileRef.current?.files;
+    if (!picked || picked.length === 0) {
+      setError("Choose a file to upload");
+      return;
+    }
+    setError(null);
+    setUploading(true);
+    const fd = new FormData();
+    fd.set("vehicleId", v.id);
+    fd.set("kind", kind);
+    fd.set("label", docLabel.trim());
+    for (const file of picked) fd.append("files", file);
+    try {
+      const result = await uploadDocumentFn({ data: fd });
+      if ("error" in result && result.error) {
+        setError(result.error);
+        return;
+      }
+      setDocLabel("");
+      if (fileRef.current) fileRef.current.value = "";
+      await router.invalidate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  function onSearch(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    navigate({ search: { q: search.trim() } });
+  }
+
+  return (
+    <section className="mx-auto max-w-2xl space-y-4">
+      <PurchasePanel vehicleId={v.id} isOwner={isOwner} />
+
+      <form onSubmit={onUpload} className={`${card} space-y-3 p-5`}>
+        <h2 className="font-bold text-ink">Add a document</h2>
+        <p className="text-sm text-ink-muted">
+          Contracts, title, registration, insurance — images and PDFs. Photos
+          are scanned so you can search the words inside them.
+        </p>
+        {error ? <p className={errorBox}>{error}</p> : null}
+        <div className="grid grid-cols-2 gap-3">
+          <label className={labelClass}>
+            Type
+            <select
+              value={kind}
+              onChange={(e) => setKind(e.target.value)}
+              className={input}
+            >
+              {DOCUMENT_KINDS.map((k) => (
+                <option key={k} value={k}>
+                  {documentKindLabel(k)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={labelClass}>
+            Label (optional)
+            <input
+              value={docLabel}
+              onChange={(e) => setDocLabel(e.target.value)}
+              placeholder="2024 registration"
+              className={input}
+            />
+          </label>
+        </div>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*,application/pdf"
+          multiple
+          className="block w-full text-sm text-ink-muted file:mr-3 file:rounded-xl file:border-0 file:bg-sunken file:px-4 file:py-2 file:font-semibold file:text-ink"
+        />
+        <button type="submit" disabled={uploading} className={btnPrimary}>
+          {uploading ? "Uploading…" : "Upload"}
+        </button>
+      </form>
+
+      <div className={`${card} p-5`}>
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="font-bold text-ink">Documents</h2>
+          <form onSubmit={onSearch} className="flex gap-2">
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search words in scans…"
+              aria-label="Search documents"
+              className={`${input} mt-0 w-44 sm:w-56`}
+            />
+            <button type="submit" className={btnSecondary}>
+              Search
+            </button>
+          </form>
+        </div>
+
+        {q ? (
+          <p className="mt-2 text-xs text-ink-muted">
+            {documents.length} result{documents.length === 1 ? "" : "s"} for “
+            {q}”.{" "}
+            <button
+              type="button"
+              className="font-semibold text-accent hover:underline"
+              onClick={() => {
+                setSearch("");
+                navigate({ search: { q: "" } });
+              }}
+            >
+              Clear
+            </button>
+          </p>
+        ) : null}
+
+        {documents.length === 0 ? (
+          <p className="mt-3 text-sm text-ink-muted">
+            {q ? "No documents match that search." : "No documents yet."}
+          </p>
+        ) : (
+          <ul className="mt-3 divide-y divide-line">
+            {documents.map((doc) => {
+              const canDelete = isOwner || doc.uploadedById === userId;
+              return (
+                <li key={doc.id} className="flex items-start gap-3 py-3">
+                  <div className="min-w-0 flex-1">
+                    <a
+                      href={`/files/${doc.path}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-semibold text-accent hover:underline"
+                    >
+                      {doc.label || doc.originalName || "Document"}
+                    </a>
+                    <p className="mt-0.5 text-xs text-ink-muted">
+                      {formatDateOnly(doc.createdAt)}
+                      {doc.uploaderName ? ` · ${doc.uploaderName}` : ""}
+                      {doc.extractedText ? " · searchable" : ""}
+                    </p>
+                  </div>
+                  {isOwner ? (
+                    <select
+                      value={doc.kind}
+                      aria-label="Document type"
+                      onChange={async (e) => {
+                        await retagDocumentFn({
+                          data: {
+                            vehicleId: v.id,
+                            id: doc.id,
+                            kind: e.target.value,
+                          },
+                        });
+                        await router.invalidate();
+                      }}
+                      className={`${input} mt-0 w-auto shrink-0 text-xs`}
+                    >
+                      {DOCUMENT_KINDS.map((k) => (
+                        <option key={k} value={k}>
+                          {documentKindLabel(k)}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <span className="shrink-0 rounded-full bg-sunken px-3 py-1 text-xs font-semibold text-ink-muted">
+                      {documentKindLabel(doc.kind)}
+                    </span>
+                  )}
+                  {canDelete ? (
+                    <button
+                      type="button"
+                      className="min-h-11 shrink-0 px-2 text-xs font-semibold text-danger hover:underline"
+                      onClick={async () => {
+                        if (!window.confirm("Delete this document?")) return;
+                        await deleteDocumentFn({
+                          data: { vehicleId: v.id, id: doc.id },
+                        });
+                        await router.invalidate();
+                      }}
+                    >
+                      Delete
+                    </button>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/routes/_authed.vehicles.$vehicleId.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.tsx
@@ -30,6 +30,7 @@ const tabs = [
   { to: "/vehicles/$vehicleId/logs", label: "Logs", exact: false },
   { to: "/vehicles/$vehicleId/reminders", label: "Reminders", exact: false },
   { to: "/vehicles/$vehicleId/projects", label: "Projects", exact: false },
+  { to: "/vehicles/$vehicleId/documents", label: "Documents", exact: false },
 ] as const;
 
 function VehicleLayout() {

--- a/app/routes/account.export.tsx
+++ b/app/routes/account.export.tsx
@@ -12,6 +12,7 @@ import {
   parts,
   tags,
   users,
+  vehicleDocuments,
   vehicles,
 } from "~/db/schema";
 
@@ -51,7 +52,7 @@ export const Route = createFileRoute("/account/export")({
           ),
         );
 
-        const [tagJoins, partJoins, mechanicRows, readingRows] =
+        const [tagJoins, partJoins, mechanicRows, readingRows, documentRows] =
           await Promise.all([
             logIds.length
               ? db
@@ -77,6 +78,12 @@ export const Route = createFileRoute("/account/export")({
                   .from(odometerReadings)
                   .where(inArray(odometerReadings.vehicleId, vehicleIds))
               : Promise.resolve([]),
+            vehicleIds.length
+              ? db
+                  .select()
+                  .from(vehicleDocuments)
+                  .where(inArray(vehicleDocuments.vehicleId, vehicleIds))
+              : Promise.resolve([]),
           ]);
 
         const tagIds = Array.from(new Set(tagJoins.map((j) => j.tagId)));
@@ -101,6 +108,10 @@ export const Route = createFileRoute("/account/export")({
           })),
           logs: userLogs,
           odometerReadings: readingRows,
+          vehicleDocuments: documentRows.map((d) => ({
+            ...d,
+            fileUrl: `/files/${d.path}`,
+          })),
           mechanics: mechanicRows,
           tags: tagRows,
           parts: partRows,

--- a/app/scan/extract.server.ts
+++ b/app/scan/extract.server.ts
@@ -10,7 +10,10 @@
 
 import { Buffer } from "node:buffer";
 
-import { extractReceipt as extractWithOllama } from "~/scan/ollama.server";
+import {
+  extractReceipt as extractWithOllama,
+  transcribeImage as transcribeWithOllama,
+} from "~/scan/ollama.server";
 import {
   EXTRACTION_PROMPT,
   type ExtractedReceipt,
@@ -199,6 +202,70 @@ async function runWorkersAiExtraction(
       max_tokens: 2048,
     });
     return normalizeReceipt(parseWorkersAiResponse(structured));
+  }
+}
+
+const TRANSCRIBE_PROMPT =
+  "Transcribe every piece of text visible in this document image exactly as " +
+  "written — names, dates, amounts, policy/VIN/plate numbers, addresses, and " +
+  "any fine print. Output only the transcribed text, no commentary. If the " +
+  "image contains no legible text, respond with an empty string.";
+
+/**
+ * Best-effort OCR for a vehicle document image, used to make scans
+ * full-text searchable. Returns the transcribed text, or null when no vision
+ * backend is reachable or the model returns nothing. Never throws: a failed
+ * transcription just means the document is searchable by label/filename only,
+ * so callers store the file regardless.
+ */
+export async function transcribeImage(
+  image: Uint8Array,
+  contentType = "image/jpeg",
+): Promise<string | null> {
+  const workersAi = await getWorkersAi();
+
+  if (workersAi) {
+    const dataUrl = `data:${contentType};base64,${Buffer.from(image).toString("base64")}`;
+    const run = () =>
+      workersAi.ai.run(workersAi.model, {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: TRANSCRIBE_PROMPT },
+              { type: "image_url", image_url: { url: dataUrl } },
+            ],
+          },
+        ],
+        temperature: 0,
+        max_tokens: 2048,
+      });
+    try {
+      const text = workersAiResponseText(await run());
+      if (text?.trim()) return text.trim();
+    } catch (err) {
+      if (isLicenseAgreementError(err)) {
+        try {
+          await workersAi.ai.run(workersAi.model, { prompt: "agree" });
+          const text = workersAiResponseText(await run());
+          if (text?.trim()) return text.trim();
+        } catch {
+          // fall through to the Ollama attempt / null
+        }
+      }
+    }
+  }
+
+  // Same reasoning as extractReceiptScan: localhost Ollama only exists on
+  // Node self-host or local dev. On deployed Workers, skip it.
+  const isDev = (import.meta as { env?: { DEV?: boolean } }).env?.DEV === true;
+  if (workersAi && !isDev) return null;
+
+  try {
+    const text = await transcribeWithOllama(image);
+    return text?.trim() ? text.trim() : null;
+  } catch {
+    return null;
   }
 }
 

--- a/app/scan/ollama.server.ts
+++ b/app/scan/ollama.server.ts
@@ -82,3 +82,44 @@ export async function extractReceipt(
 
   return normalizeReceipt(parsed);
 }
+
+const TRANSCRIBE_PROMPT =
+  "Transcribe every piece of text visible in this document image exactly as " +
+  "written. Output only the transcribed text, no commentary.";
+
+/**
+ * Plain-text OCR of one image via the local vision model — no schema, just
+ * the transcription. Used to make uploaded vehicle documents searchable on
+ * Node self-host / dev. Throws on transport/model errors; the caller treats
+ * a failure as "no extracted text".
+ */
+export async function transcribeImage(
+  image: Uint8Array,
+  config: OllamaConfig = DEFAULT_OLLAMA,
+): Promise<string | null> {
+  const base64 = Buffer.from(image).toString("base64");
+
+  const res = await fetch(`${config.host}/api/chat`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: config.model,
+      stream: false,
+      messages: [
+        { role: "user", content: TRANSCRIBE_PROMPT, images: [base64] },
+      ],
+      options: { temperature: 0 },
+    }),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(
+      `Ollama ${res.status} ${res.statusText}${detail ? `: ${detail}` : ""}`,
+    );
+  }
+
+  const data = (await res.json()) as OllamaChatResponse;
+  if (data.error) throw new Error(`Ollama error: ${data.error}`);
+  return data.message?.content?.trim() ?? null;
+}


### PR DESCRIPTION
## What

Adds a **Documents** tab to every vehicle for storing acquisition paperwork and structured purchase details — and makes scanned images **full-text searchable** by OCRing them on upload.

Closes the request to "store vehicle purchase information (contracts, registration records, etc.)" plus the follow-ups: **tag documents by type** and **search the words inside the images**.

## Changes

**Schema** (`migration 0007`)
- Purchase columns on `vehicles`: `purchased_at`, `purchase_price`, `purchase_odometer`, `seller`, `purchase_note`.
- New `vehicle_documents` table: vehicle-scoped files with a `kind` tag, an `extracted_text` OCR column, an uploader, and a generated `search_tsv` GIN index (the same FTS pattern `logs` uses).

**OCR — "search words in the images"**
- `transcribeImage()` added to the existing vision seam (`extract.server.ts` / `ollama.server.ts`): Workers AI on Cloudflare, local Ollama on Node/dev. Runs on image upload, **best-effort** — a failure never blocks the upload; the doc is just searchable by label/filename only. No paid API, consistent with the Scan Bay cost decision.
- `searchVehicleDocuments()` runs `websearch_to_tsquery` over OCR text + label + filename, so a policy number or VIN that only appears inside a photo still hits.

**Tagging** — seven kinds (`purchase`, `title`, `registration`, `insurance`, `bill_of_sale`, `warranty`, `other`); vocab in `document.shared.ts` so client routes can import it. Owners retag inline from the list.

**Model / UI**
- `document.server.ts` (upload + OCR, search, retag, uploader-or-owner delete, blob reap on vehicle delete) and `updatePurchase()` on `vehicle.server.ts` (owner-only).
- Documents tab: owner-editable purchase panel, tagged upload (images + PDFs, 12 MB cap), search box, document list with view links and delete.

**Plumbing** — documents ship in `GET /account/export`; blobs reaped on vehicle delete; CLAUDE.md + README updated.

## Access model
- Purchase edits: **owner-only** (matches vehicle edit).
- View/upload documents: **any crew member** (matches log attachments).
- Delete: **uploader or owner** (matches manual odometer readings).

## Testing
- `npm run validate` green: typecheck + lint + **83 tests** (9 new document-model tests covering upload, kind coercion, FTS, retag, access denial, delete permissions, and blob reaping).
- Clean `npm run build` (Cloudflare Workers — catches import-protection issues typecheck misses).

## Notes / deliberate choices
- Documents are stored **full-resolution** (not downscaled like avatars/scans) — a contract or title should stay legible; OCR runs fine on the full image.
- **Not exposed via MCP** — kept scope to the app. A `list_documents` tool or purchase info in `get_vehicle_status` would be an easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)