### PR TITLE
feat(drive): one-way Google Drive sync of documents, scans, and data export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,17 @@ SESSION_SECRET="change-me-to-something-random-at-least-32-chars-long"
 # Uploads directory (self-host only, ignored on Cloudflare)
 UPLOADS_DIR="./data/uploads"
 
+# Google Drive sync (optional). When all three are set, the Profile page shows
+# a "Sync to Google Drive" panel that copies documents, scans, and a JSON
+# export into a "Logbook" folder in the user's Drive (drive.file scope — the
+# app only ever sees files it created). Create an OAuth 2.0 "Web application"
+# client in Google Cloud Console (Drive API enabled), and add the redirect URI
+# http://localhost:3000/auth/google/callback for local dev.
+# GOOGLE_OAUTH_CLIENT_ID="xxxx.apps.googleusercontent.com"
+# GOOGLE_OAUTH_CLIENT_SECRET="xxxx"
+# Key that encrypts stored Google refresh tokens. Generate: openssl rand -base64 32
+# GOOGLE_TOKEN_KEY="change-me-32-random-bytes-base64"
+
 # Scan Bay — local receipt extraction. Both optional; defaults shown. Points
 # the batch CLI (npm run scan:extract) AND the in-app scan page's Node/dev
 # fallback at a local Ollama with a vision model. On Cloudflare the in-app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,12 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
    close/completion dates — a single-date receipt fills only the close;
    `odometer_readings`: standalone mileage entries (odometer, read_at, note,
    user_id) — "last odometer" is latest-by-date across logs + manual readings,
-   ties broken by higher miles)
+   ties broken by higher miles;
+   `google_connections`: per-user Google Drive OAuth-client tokens (Logbook is
+   the OAuth *client* here, the opposite role from the MCP server) — `drive.file`
+   scope only, refresh token AES-GCM encrypted at rest, access token cached;
+   `drive_synced_files`: idempotent map of synced source → Drive file/folder id
+   so re-syncing skips already-uploaded blobs and reuses folders)
 2. `app/db/client.ts` — postgres-js client, runtime-aware
 3. `app/db/migrations/` — generated SQL (do not edit by hand unless
    adding CREATE EXTENSION-style ops that Drizzle can't infer)
@@ -158,7 +163,12 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
    `odometer.server.ts` (union latest across logs + manual readings, batch
    helper, history, create/delete — deletes restricted to author-or-owner),
    `vehicle-form.server.ts` (shared parse + avatar store + avatar reap for
-   create and edit routes)
+   create and edit routes),
+   `export.server.ts` (`buildUserExport` — the full "your data" JSON bundle,
+   shared by the `/account/export` download and the Drive sync),
+   `google-drive.server.ts` (one-way app → Drive sync: connection CRUD with
+   token refresh/caching, `syncToDrive` over owned vehicles' documents + log
+   attachments + the JSON export, idempotent via `drive_synced_files`)
 8. `app/lib/` — isomorphic client utilities (safe to call from route
    components): `image.ts` (`downscaleImage` — shared JPEG downscale used
    by the scan page ~1600px and avatar uploads ~1024px; deliberately NOT
@@ -186,10 +196,24 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
     `_authed.vehicles.$vehicleId.documents.tsx` (Documents tab: owner-only
     purchase-details panel + tagged document upload + FTS search box over
     OCR'd text/label/filename + document list with retag and uploader-or-
-    owner delete), and `authorize.tsx`
+    owner delete), `authorize.tsx`
     (OAuth consent for the MCP server — server handlers only, renders
-    plain HTML, reuses session auth); `app/components/VehicleForm.tsx`
+    plain HTML, reuses session auth), and the Google Drive connect flow
+    `auth.google.start.tsx` / `auth.google.callback.tsx` (server handlers:
+    redirect to Google consent with a signed `state`, exchange the code,
+    store the connection; both land back on `/profile?drive=…`). The Drive
+    sync panel (connect / sync-now / disconnect) lives on
+    `_authed.profile.tsx`. `app/components/VehicleForm.tsx`
     is the shared create/edit form (vPIC assists + avatar downscale)
+11b. `app/google/` — Google Drive integration helpers (server-only): `oauth.server.ts`
+    (`drive.file` + `openid email` scopes, code/refresh exchange, revoke,
+    `isGoogleDriveConfigured`), `drive.server.ts` (minimal Drive v3 REST —
+    create folder, multipart upload, update content, existence check),
+    `crypto.server.ts` (AES-GCM at-rest encryption of refresh tokens, keyed by
+    `GOOGLE_TOKEN_KEY`), `state.server.ts` (stateless HMAC-signed OAuth `state`
+    keyed by `SESSION_SECRET`, bound to the user). Creds come from
+    `process.env` (`GOOGLE_OAUTH_CLIENT_ID`/`_SECRET`, `GOOGLE_TOKEN_KEY`) —
+    same `process.env` path as `SESSION_SECRET`, so no new wrangler binding.
 11. `server.ts` + `app/mcp/` — Worker entry (`main` in wrangler.jsonc):
     wraps the TanStack handler in `workers-oauth-provider`, mounts
     `LogbookMCP.serve("/mcp")`, and re-exports the `LogbookMCP` Durable

--- a/README.md
+++ b/README.md
@@ -357,6 +357,41 @@ out of the client bundle.
 `schemaVersion` gives future importers a hook to evolve the format without
 breaking old bundles.
 
+## Sync to Google Drive
+
+Optionally back your records up to your own Google Drive. From **Profile →
+Sync to Google Drive**, connect a Google account and hit **Sync now**: Logbook
+creates a single `Logbook` folder and copies your vehicle documents, receipt
+scans, and a full JSON export (the same bundle as above) into it, organized
+per vehicle.
+
+It uses Google's [`drive.file`](https://developers.google.com/drive/api/guides/api-specific-auth)
+scope — the **least-privilege** Drive scope. Logbook can only see and modify
+files **it created**; it can't list, read, or touch anything else in your
+Drive. The sync is one-way (app → Drive) and idempotent: re-running only
+uploads what's new and refreshes the JSON export. Disconnecting revokes the
+grant at Google and drops the stored tokens.
+
+Refresh tokens are encrypted at rest (AES-GCM) and the OAuth `state` is HMAC
+-signed and bound to your session, so the connect flow can't be hijacked.
+
+**Setup (operator).** The feature stays hidden until configured. In Google
+Cloud Console: create an OAuth 2.0 **Web application** client, enable the
+**Drive API**, set the consent screen's scope to `.../auth/drive.file`, and add
+the redirect URI `https://<your-domain>/auth/google/callback` (plus
+`http://localhost:3000/auth/google/callback` for dev). Then provide three
+values — as Wrangler secrets on Cloudflare, or env vars for Node self-host:
+
+```sh
+# Cloudflare Workers
+wrangler secret put GOOGLE_OAUTH_CLIENT_ID
+wrangler secret put GOOGLE_OAUTH_CLIENT_SECRET
+wrangler secret put GOOGLE_TOKEN_KEY        # openssl rand -base64 32
+```
+
+For local dev put the same three keys in `.dev.vars` (and `.env` for Node
+tooling). See `.env.example`.
+
 ## Scan Bay — digitizing paper records
 
 A big part of Logbook is getting a backlog of paper shop invoices into the

--- a/app/db/migrations/0008_lowly_kree.sql
+++ b/app/db/migrations/0008_lowly_kree.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "drive_synced_files" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"source_type" text NOT NULL,
+	"source_key" text NOT NULL,
+	"drive_file_id" text NOT NULL,
+	"synced_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "google_connections" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"google_email" text,
+	"refresh_token_enc" text NOT NULL,
+	"access_token" text,
+	"access_token_expires_at" timestamp with time zone,
+	"root_folder_id" text,
+	"scope" text,
+	"last_synced_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "drive_synced_files" ADD CONSTRAINT "drive_synced_files_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "google_connections" ADD CONSTRAINT "google_connections_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+CREATE UNIQUE INDEX "drive_synced_files_source_idx" ON "drive_synced_files" USING btree ("user_id","source_type","source_key");

--- a/app/db/migrations/meta/0008_snapshot.json
+++ b/app/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1852 @@
+{
+  "id": "cab12e61-8ebb-47a3-9f70-847dc8519f1e",
+  "prevId": "7dfdf80d-4ce9-4b7d-b4fc-bd7e628d2e53",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.drive_synced_files": {
+      "name": "drive_synced_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_file_id": {
+          "name": "drive_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_synced_files_source_idx": {
+          "name": "drive_synced_files_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_synced_files_user_id_users_id_fk": {
+          "name": "drive_synced_files_user_id_users_id_fk",
+          "tableFrom": "drive_synced_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_connections": {
+      "name": "google_connections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "google_email": {
+          "name": "google_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_folder_id": {
+          "name": "root_folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "google_connections_user_id_users_id_fk": {
+          "name": "google_connections_user_id_users_id_fk",
+          "tableFrom": "google_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_attachments": {
+      "name": "log_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "log_attachments_log_idx": {
+          "name": "log_attachments_log_idx",
+          "columns": [
+            {
+              "expression": "log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "log_attachments_log_id_logs_id_fk": {
+          "name": "log_attachments_log_id_logs_id_fk",
+          "tableFrom": "log_attachments",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_started_at": {
+          "name": "service_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serviced_at": {
+          "name": "serviced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "self_service": {
+          "name": "self_service",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mechanic_id": {
+          "name": "mechanic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(\"logs\".\"title\", '') || ' ' || coalesce(\"logs\".\"notes\", ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_search_idx": {
+          "name": "logs_search_idx",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "logs_vehicle_idx": {
+          "name": "logs_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_user_idx": {
+          "name": "logs_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "logs_user_id_users_id_fk": {
+          "name": "logs_user_id_users_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "logs_vehicle_id_vehicles_id_fk": {
+          "name": "logs_vehicle_id_vehicles_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "logs_mechanic_id_mechanics_id_fk": {
+          "name": "logs_mechanic_id_mechanics_id_fk",
+          "tableFrom": "logs",
+          "tableTo": "mechanics",
+          "columnsFrom": [
+            "mechanic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_to_parts": {
+      "name": "logs_to_parts",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "part_id": {
+          "name": "part_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logs_to_parts_log_id_logs_id_fk": {
+          "name": "logs_to_parts_log_id_logs_id_fk",
+          "tableFrom": "logs_to_parts",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "logs_to_parts_part_id_parts_id_fk": {
+          "name": "logs_to_parts_part_id_parts_id_fk",
+          "tableFrom": "logs_to_parts",
+          "tableTo": "parts",
+          "columnsFrom": [
+            "part_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "logs_to_parts_log_id_part_id_pk": {
+          "name": "logs_to_parts_log_id_part_id_pk",
+          "columns": [
+            "log_id",
+            "part_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs_to_tags": {
+      "name": "logs_to_tags",
+      "schema": "",
+      "columns": {
+        "log_id": {
+          "name": "log_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "logs_to_tags_log_id_logs_id_fk": {
+          "name": "logs_to_tags_log_id_logs_id_fk",
+          "tableFrom": "logs_to_tags",
+          "tableTo": "logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "logs_to_tags_tag_id_tags_id_fk": {
+          "name": "logs_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "logs_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "logs_to_tags_log_id_tag_id_pk": {
+          "name": "logs_to_tags_log_id_tag_id_pk",
+          "columns": [
+            "log_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mechanics": {
+      "name": "mechanics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mechanics_email_idx": {
+          "name": "mechanics_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.odometer_readings": {
+      "name": "odometer_readings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "odometer": {
+          "name": "odometer",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "odometer_readings_vehicle_idx": {
+          "name": "odometer_readings_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "odometer_readings_user_id_users_id_fk": {
+          "name": "odometer_readings_user_id_users_id_fk",
+          "tableFrom": "odometer_readings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "odometer_readings_vehicle_id_vehicles_id_fk": {
+          "name": "odometer_readings_vehicle_id_vehicles_id_fk",
+          "tableFrom": "odometer_readings",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parts": {
+      "name": "parts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passwords": {
+      "name": "passwords",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passwords_user_id_users_id_fk": {
+          "name": "passwords_user_id_users_id_fk",
+          "tableFrom": "passwords",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passwords_user_id_unique": {
+          "name": "passwords_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_items": {
+      "name": "project_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_items_project_idx": {
+          "name": "project_items_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_items_project_id_projects_id_fk": {
+          "name": "project_items_project_id_projects_id_fk",
+          "tableFrom": "project_items",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idea'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_vehicle_idx": {
+          "name": "projects_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_vehicle_id_vehicles_id_fk": {
+          "name": "projects_vehicle_id_vehicles_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "projects_created_by_id_users_id_fk": {
+          "name": "projects_created_by_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reminders": {
+      "name": "reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_miles": {
+          "name": "due_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_months": {
+          "name": "interval_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_miles": {
+          "name": "interval_miles",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reminders_vehicle_idx": {
+          "name": "reminders_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reminders_vehicle_id_vehicles_id_fk": {
+          "name": "reminders_vehicle_id_vehicles_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "reminders_created_by_id_users_id_fk": {
+          "name": "reminders_created_by_id_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_documents": {
+      "name": "vehicle_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_tsv": {
+          "name": "search_tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(\"vehicle_documents\".\"label\", '') || ' ' || coalesce(\"vehicle_documents\".\"original_name\", '') || ' ' || coalesce(\"vehicle_documents\".\"extracted_text\", ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_documents_vehicle_idx": {
+          "name": "vehicle_documents_vehicle_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vehicle_documents_search_idx": {
+          "name": "vehicle_documents_search_idx",
+          "columns": [
+            {
+              "expression": "search_tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_documents_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_documents_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_documents",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_documents_uploaded_by_id_users_id_fk": {
+          "name": "vehicle_documents_uploaded_by_id_users_id_fk",
+          "tableFrom": "vehicle_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_invites": {
+      "name": "vehicle_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_invites_vehicle_email_idx": {
+          "name": "vehicle_invites_vehicle_email_idx",
+          "columns": [
+            {
+              "expression": "vehicle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vehicle_invites_email_idx": {
+          "name": "vehicle_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_invites_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_invites_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_invites",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_invites_invited_by_id_users_id_fk": {
+          "name": "vehicle_invites_invited_by_id_users_id_fk",
+          "tableFrom": "vehicle_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicle_members": {
+      "name": "vehicle_members",
+      "schema": "",
+      "columns": {
+        "vehicle_id": {
+          "name": "vehicle_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vehicle_members_user_idx": {
+          "name": "vehicle_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vehicle_members_vehicle_id_vehicles_id_fk": {
+          "name": "vehicle_members_vehicle_id_vehicles_id_fk",
+          "tableFrom": "vehicle_members",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "vehicle_members_user_id_users_id_fk": {
+          "name": "vehicle_members_user_id_users_id_fk",
+          "tableFrom": "vehicle_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vehicle_members_vehicle_id_user_id_pk": {
+          "name": "vehicle_members_vehicle_id_user_id_pk",
+          "columns": [
+            "vehicle_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trim": {
+          "name": "trim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vin": {
+          "name": "vin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engine": {
+          "name": "engine",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_odometer": {
+          "name": "purchase_odometer",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seller": {
+          "name": "seller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_note": {
+          "name": "purchase_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vehicles_user_id_users_id_fk": {
+          "name": "vehicles_user_id_users_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/db/migrations/meta/_journal.json
+++ b/app/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1781472693558,
       "tag": "0007_swift_santa_claus",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1781487541446,
+      "tag": "0008_lowly_kree",
+      "breakpoints": true
     }
   ]
 }

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -391,6 +391,67 @@ export const odometerReadings = pgTable(
   (t) => [index("odometer_readings_vehicle_idx").on(t.vehicleId)],
 );
 
+// Per-user Google Drive connection. Here Logbook is the OAuth *client* (the
+// user authorizes Logbook to write into their Drive) — the opposite role from
+// the MCP server, where Logbook is the OAuth provider. The `drive.file` scope
+// means Logbook can only see and touch files it created itself, never the
+// rest of the user's Drive. `refreshTokenEnc` is AES-GCM encrypted at rest
+// (see app/google/crypto.server.ts); the access token is cached until expiry.
+export const googleConnections = pgTable("google_connections", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => users.id, { onDelete: "cascade", onUpdate: "cascade" }),
+  // The Google account the tokens belong to, for display. Filled from the
+  // OpenID `email` scope at connect time.
+  googleEmail: text("google_email"),
+  refreshTokenEnc: text("refresh_token_enc").notNull(),
+  accessToken: text("access_token"),
+  accessTokenExpiresAt: timestamp("access_token_expires_at", {
+    withTimezone: true,
+    mode: "date",
+  }),
+  // The id of the "Logbook" root folder created in the user's Drive.
+  rootFolderId: text("root_folder_id"),
+  scope: text(),
+  lastSyncedAt: timestamp("last_synced_at", {
+    withTimezone: true,
+    mode: "date",
+  }),
+  ...timestamps,
+});
+
+// Maps a synced source object to the file/folder Logbook created in the user's
+// Drive, so re-syncing is idempotent and resumable: an already-synced
+// immutable blob (a vehicle document or log attachment) is skipped, folders
+// are reused, and the JSON export is updated in place. Rows cascade when the
+// user (or their connection) is deleted.
+export const driveSyncedFiles = pgTable(
+  "drive_synced_files",
+  {
+    id: cuid2().primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade", onUpdate: "cascade" }),
+    // "folder" | "vehicle_document" | "log_attachment" | "export"
+    sourceType: text("source_type").notNull(),
+    // Stable key within sourceType: a document/attachment id, a folder path
+    // like "vehicle:<id>" or "vehicle:<id>:documents", or "export".
+    sourceKey: text("source_key").notNull(),
+    driveFileId: text("drive_file_id").notNull(),
+    syncedAt: timestamp("synced_at", { withTimezone: true, mode: "date" })
+      .notNull()
+      .defaultNow(),
+    ...timestamps,
+  },
+  (t) => [
+    uniqueIndex("drive_synced_files_source_idx").on(
+      t.userId,
+      t.sourceType,
+      t.sourceKey,
+    ),
+  ],
+);
+
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type Vehicle = typeof vehicles.$inferSelect;
@@ -414,3 +475,7 @@ export type VehicleDocument = typeof vehicleDocuments.$inferSelect;
 export type NewVehicleDocument = typeof vehicleDocuments.$inferInsert;
 export type OdometerReading = typeof odometerReadings.$inferSelect;
 export type NewOdometerReading = typeof odometerReadings.$inferInsert;
+export type GoogleConnection = typeof googleConnections.$inferSelect;
+export type NewGoogleConnection = typeof googleConnections.$inferInsert;
+export type DriveSyncedFile = typeof driveSyncedFiles.$inferSelect;
+export type NewDriveSyncedFile = typeof driveSyncedFiles.$inferInsert;

--- a/app/google/crypto.server.test.ts
+++ b/app/google/crypto.server.test.ts
@@ -1,0 +1,36 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { decryptSecret, encryptSecret } from "./crypto.server";
+
+beforeAll(() => {
+  // 32 bytes of base64 — the encryption key the helper expects.
+  process.env.GOOGLE_TOKEN_KEY = btoa("0123456789abcdef0123456789abcdef");
+});
+
+describe("token encryption", () => {
+  it("round-trips a secret", async () => {
+    const secret = "1//refresh-token-value-abc.def_ghi";
+    const encrypted = await encryptSecret(secret);
+    expect(encrypted).not.toContain(secret);
+    expect(await decryptSecret(encrypted)).toBe(secret);
+  });
+
+  it("produces a different ciphertext each time (random IV)", async () => {
+    const a = await encryptSecret("same");
+    const b = await encryptSecret("same");
+    expect(a).not.toBe(b);
+    expect(await decryptSecret(a)).toBe("same");
+    expect(await decryptSecret(b)).toBe("same");
+  });
+
+  it("rejects a malformed payload", async () => {
+    await expect(decryptSecret("not-valid")).rejects.toThrow();
+  });
+
+  it("fails when the key length is wrong", async () => {
+    const original = process.env.GOOGLE_TOKEN_KEY;
+    process.env.GOOGLE_TOKEN_KEY = btoa("too-short");
+    await expect(encryptSecret("x")).rejects.toThrow(/32 bytes/);
+    process.env.GOOGLE_TOKEN_KEY = original;
+  });
+});

--- a/app/google/crypto.server.ts
+++ b/app/google/crypto.server.ts
@@ -1,0 +1,76 @@
+/**
+ * AES-GCM encryption for secrets at rest — used to protect Google refresh
+ * tokens before they're written to Postgres. WebCrypto (`globalThis.crypto`)
+ * is available on both Cloudflare Workers and Node 24, so this stays
+ * runtime-agnostic like the rest of the app.
+ *
+ * The key comes from the GOOGLE_TOKEN_KEY env var: 32 random bytes encoded as
+ * base64 (generate with `openssl rand -base64 32`). Ciphertext is stored as
+ * `base64(iv).base64(ciphertext+tag)` so a stored value is self-describing.
+ */
+
+const IV_BYTES = 12; // 96-bit nonce, the AES-GCM standard.
+
+function getKeyMaterial(): Uint8Array {
+  const raw = process.env.GOOGLE_TOKEN_KEY;
+  if (!raw) {
+    throw new Error(
+      "GOOGLE_TOKEN_KEY is required to encrypt Google Drive tokens",
+    );
+  }
+  const bytes = base64ToBytes(raw.trim());
+  if (bytes.length !== 32) {
+    throw new Error(
+      "GOOGLE_TOKEN_KEY must decode to 32 bytes (generate with `openssl rand -base64 32`)",
+    );
+  }
+  return bytes;
+}
+
+async function importKey(usage: "encrypt" | "decrypt"): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    getKeyMaterial() as BufferSource,
+    { name: "AES-GCM" },
+    false,
+    [usage],
+  );
+}
+
+export async function encryptSecret(plaintext: string): Promise<string> {
+  const key = await importKey("encrypt");
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const ct = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(plaintext) as BufferSource,
+  );
+  return `${bytesToBase64(iv)}.${bytesToBase64(new Uint8Array(ct))}`;
+}
+
+export async function decryptSecret(stored: string): Promise<string> {
+  const [ivPart, ctPart] = stored.split(".");
+  if (!ivPart || !ctPart) {
+    throw new Error("Malformed encrypted secret");
+  }
+  const key = await importKey("decrypt");
+  const pt = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: base64ToBytes(ivPart) as BufferSource },
+    key,
+    base64ToBytes(ctPart) as BufferSource,
+  );
+  return new TextDecoder().decode(pt);
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}

--- a/app/google/drive.server.ts
+++ b/app/google/drive.server.ts
@@ -1,0 +1,155 @@
+/**
+ * Minimal Google Drive v3 REST client — just the calls the one-way sync needs:
+ * create a folder, upload a new file, replace a file's contents, and check a
+ * file still exists. Plain `fetch` with a bearer access token, so it runs on
+ * both Cloudflare Workers and Node.
+ *
+ * Everything here is scoped by the `drive.file` grant: these calls only ever
+ * see or touch files Logbook itself created.
+ */
+
+const FILES_ENDPOINT = "https://www.googleapis.com/drive/v3/files";
+const UPLOAD_ENDPOINT = "https://www.googleapis.com/upload/drive/v3/files";
+const FOLDER_MIME = "application/vnd.google-apps.folder";
+
+/** Create a folder (optionally inside `parentId`); returns its Drive file id. */
+export async function createFolder({
+  accessToken,
+  name,
+  parentId,
+}: {
+  accessToken: string;
+  name: string;
+  parentId?: string;
+}): Promise<string> {
+  const res = await fetch(`${FILES_ENDPOINT}?fields=id`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      name,
+      mimeType: FOLDER_MIME,
+      ...(parentId ? { parents: [parentId] } : {}),
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Drive folder create failed: ${await res.text()}`);
+  }
+  const { id } = (await res.json()) as { id: string };
+  return id;
+}
+
+/**
+ * Upload a brand-new file via a single multipart/related request (metadata +
+ * bytes in one round trip). Returns the new Drive file id.
+ */
+export async function uploadFile({
+  accessToken,
+  name,
+  mimeType,
+  body,
+  parentId,
+}: {
+  accessToken: string;
+  name: string;
+  mimeType: string;
+  body: Uint8Array;
+  parentId?: string;
+}): Promise<string> {
+  const boundary = `logbook-${crypto.randomUUID()}`;
+  const metadata = JSON.stringify({
+    name,
+    ...(parentId ? { parents: [parentId] } : {}),
+  });
+
+  const preamble =
+    `--${boundary}\r\n` +
+    "Content-Type: application/json; charset=UTF-8\r\n\r\n" +
+    `${metadata}\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Type: ${mimeType}\r\n\r\n`;
+  const epilogue = `\r\n--${boundary}--`;
+  const requestBody = concatBytes(
+    new TextEncoder().encode(preamble),
+    body,
+    new TextEncoder().encode(epilogue),
+  );
+
+  const res = await fetch(`${UPLOAD_ENDPOINT}?uploadType=multipart&fields=id`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      "content-type": `multipart/related; boundary=${boundary}`,
+    },
+    body: requestBody as BodyInit,
+  });
+  if (!res.ok) {
+    throw new Error(`Drive upload failed: ${await res.text()}`);
+  }
+  const { id } = (await res.json()) as { id: string };
+  return id;
+}
+
+/** Replace the contents of an existing Drive file (used for the JSON export). */
+export async function updateFileContent({
+  accessToken,
+  fileId,
+  mimeType,
+  body,
+}: {
+  accessToken: string;
+  fileId: string;
+  mimeType: string;
+  body: Uint8Array;
+}): Promise<void> {
+  const res = await fetch(
+    `${UPLOAD_ENDPOINT}/${encodeURIComponent(fileId)}?uploadType=media`,
+    {
+      method: "PATCH",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "content-type": mimeType,
+      },
+      body: body as BodyInit,
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Drive update failed: ${await res.text()}`);
+  }
+}
+
+/**
+ * Whether a tracked file/folder still exists (not deleted/trashed in Drive).
+ * Lets the sync recover when a user manually removed something we mapped.
+ */
+export async function fileExists({
+  accessToken,
+  fileId,
+}: {
+  accessToken: string;
+  fileId: string;
+}): Promise<boolean> {
+  const res = await fetch(
+    `${FILES_ENDPOINT}/${encodeURIComponent(fileId)}?fields=id,trashed`,
+    { headers: { authorization: `Bearer ${accessToken}` } },
+  );
+  if (res.status === 404) return false;
+  if (!res.ok) {
+    throw new Error(`Drive lookup failed: ${await res.text()}`);
+  }
+  const { trashed } = (await res.json()) as { trashed?: boolean };
+  return !trashed;
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}

--- a/app/google/oauth.server.ts
+++ b/app/google/oauth.server.ts
@@ -1,0 +1,172 @@
+/**
+ * Google OAuth 2.0 client — the side where Logbook authenticates *to* Google
+ * so it can write into the user's Drive. Plain `fetch` against Google's
+ * endpoints (no `googleapis` SDK, which isn't Workers-friendly), so this runs
+ * unchanged on Cloudflare Workers and Node.
+ *
+ * Credentials come from env (process.env works on Workers with nodejs_compat,
+ * same as SESSION_SECRET): GOOGLE_OAUTH_CLIENT_ID + GOOGLE_OAUTH_CLIENT_SECRET.
+ * The redirect URI is derived per-request from the app origin and passed in.
+ *
+ * Scope is `drive.file` — Logbook can only access files it creates — plus
+ * `openid email` so we can show which Google account is connected.
+ */
+
+const AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
+const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const REVOKE_ENDPOINT = "https://oauth2.googleapis.com/revoke";
+
+export const DRIVE_SCOPES = [
+  "https://www.googleapis.com/auth/drive.file",
+  "openid",
+  "email",
+].join(" ");
+
+export type GoogleTokens = {
+  accessToken: string;
+  /** Present only on the first consent (access_type=offline + prompt=consent). */
+  refreshToken: string | null;
+  expiresInSeconds: number;
+  scope: string;
+  /** Connected Google account email, decoded from the id_token when present. */
+  email: string | null;
+};
+
+function clientCredentials(): { clientId: string; clientSecret: string } {
+  const clientId = process.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "Google Drive is not configured (set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET)",
+    );
+  }
+  return { clientId, clientSecret };
+}
+
+/** True when the server has Google OAuth credentials configured. */
+export function isGoogleDriveConfigured(): boolean {
+  return Boolean(
+    process.env.GOOGLE_OAUTH_CLIENT_ID &&
+      process.env.GOOGLE_OAUTH_CLIENT_SECRET,
+  );
+}
+
+/**
+ * Build the consent-screen URL. `access_type=offline` + `prompt=consent`
+ * force Google to return a refresh token even on re-connect, so a user who
+ * revoked access can reconnect cleanly.
+ */
+export function buildAuthUrl({
+  redirectUri,
+  state,
+}: {
+  redirectUri: string;
+  state: string;
+}): string {
+  const { clientId } = clientCredentials();
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: DRIVE_SCOPES,
+    access_type: "offline",
+    prompt: "consent",
+    include_granted_scopes: "true",
+    state,
+  });
+  return `${AUTH_ENDPOINT}?${params.toString()}`;
+}
+
+/** Exchange an authorization code for tokens. */
+export async function exchangeCode({
+  code,
+  redirectUri,
+}: {
+  code: string;
+  redirectUri: string;
+}): Promise<GoogleTokens> {
+  const { clientId, clientSecret } = clientCredentials();
+  const res = await fetch(TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      grant_type: "authorization_code",
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Google token exchange failed: ${await res.text()}`);
+  }
+  const data = (await res.json()) as {
+    access_token: string;
+    refresh_token?: string;
+    expires_in: number;
+    scope: string;
+    id_token?: string;
+  };
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
+    expiresInSeconds: data.expires_in,
+    scope: data.scope,
+    email: data.id_token ? emailFromIdToken(data.id_token) : null,
+  };
+}
+
+/** Trade a stored refresh token for a fresh access token. */
+export async function refreshAccessToken(
+  refreshToken: string,
+): Promise<{ accessToken: string; expiresInSeconds: number }> {
+  const { clientId, clientSecret } = clientCredentials();
+  const res = await fetch(TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      refresh_token: refreshToken,
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Google token refresh failed: ${await res.text()}`);
+  }
+  const data = (await res.json()) as {
+    access_token: string;
+    expires_in: number;
+  };
+  return { accessToken: data.access_token, expiresInSeconds: data.expires_in };
+}
+
+/** Best-effort revoke at Google (disconnect). Never throws. */
+export async function revokeToken(token: string): Promise<void> {
+  try {
+    await fetch(REVOKE_ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ token }),
+    });
+  } catch {
+    // The local connection is removed regardless; a failed revoke is harmless.
+  }
+}
+
+/**
+ * Pull the `email` claim out of an id_token. The token came straight from
+ * Google's TLS-protected token endpoint, so we trust the payload without
+ * verifying the signature (we never accept id_tokens from elsewhere).
+ */
+function emailFromIdToken(idToken: string): string | null {
+  const payload = idToken.split(".")[1];
+  if (!payload) return null;
+  try {
+    const json = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+    const claims = JSON.parse(json) as { email?: string };
+    return claims.email ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/app/google/state.server.test.ts
+++ b/app/google/state.server.test.ts
@@ -1,0 +1,31 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { createState, verifyState } from "./state.server";
+
+beforeAll(() => {
+  process.env.SESSION_SECRET =
+    "test-session-secret-at-least-32-characters-long";
+});
+
+describe("signed OAuth state", () => {
+  it("verifies a fresh state for the same user", async () => {
+    const state = await createState("user-1");
+    expect(await verifyState(state, "user-1")).toBe(true);
+  });
+
+  it("rejects a state bound to a different user", async () => {
+    const state = await createState("user-1");
+    expect(await verifyState(state, "user-2")).toBe(false);
+  });
+
+  it("rejects a tampered signature", async () => {
+    const state = await createState("user-1");
+    const [payload] = state.split(".");
+    expect(await verifyState(`${payload}.deadbeef`, "user-1")).toBe(false);
+  });
+
+  it("rejects null or malformed state", async () => {
+    expect(await verifyState(null, "user-1")).toBe(false);
+    expect(await verifyState("no-dot", "user-1")).toBe(false);
+  });
+});

--- a/app/google/state.server.ts
+++ b/app/google/state.server.ts
@@ -1,0 +1,94 @@
+/**
+ * Signed, stateless OAuth `state` parameter for the Google connect flow.
+ *
+ * The state is an HMAC-SHA256 token (keyed by SESSION_SECRET) carrying the
+ * logged-in user's id, a nonce, and an issue time. The callback verifies the
+ * signature, freshness, and that the embedded user matches the current
+ * session — so a forged or replayed callback can't bind a Drive account to the
+ * wrong user. Keeping it stateless avoids writing a one-shot value to the
+ * session cookie from a raw route handler.
+ */
+
+const MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes to complete consent.
+
+function secretBytes(): Uint8Array {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error("SESSION_SECRET must be set and at least 32 characters");
+  }
+  return new TextEncoder().encode(secret);
+}
+
+async function hmacKey(): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    secretBytes() as BufferSource,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+async function sign(payload: string): Promise<string> {
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    await hmacKey(),
+    new TextEncoder().encode(payload) as BufferSource,
+  );
+  return base64UrlEncode(new Uint8Array(sig));
+}
+
+export async function createState(userId: string): Promise<string> {
+  const payload = base64UrlEncode(
+    new TextEncoder().encode(
+      JSON.stringify({ u: userId, t: Date.now(), n: crypto.randomUUID() }),
+    ),
+  );
+  return `${payload}.${await sign(payload)}`;
+}
+
+export async function verifyState(
+  state: string | null,
+  userId: string,
+): Promise<boolean> {
+  if (!state) return false;
+  const [payload, sig] = state.split(".");
+  if (!payload || !sig) return false;
+  if (!timingSafeEqual(sig, await sign(payload))) return false;
+  try {
+    const data = JSON.parse(
+      new TextDecoder().decode(base64UrlDecode(payload)),
+    ) as { u?: string; t?: number };
+    if (data.u !== userId) return false;
+    if (typeof data.t !== "number" || Date.now() - data.t > MAX_AGE_MS) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64UrlDecode(b64url: string): Uint8Array {
+  const b64 = b64url.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}

--- a/app/models/export.server.ts
+++ b/app/models/export.server.ts
@@ -1,0 +1,111 @@
+import { eq, inArray } from "drizzle-orm";
+
+import { getDb } from "~/db/client";
+import {
+  logs,
+  logsToParts,
+  logsToTags,
+  mechanics,
+  odometerReadings,
+  parts,
+  tags,
+  users,
+  vehicleDocuments,
+  vehicles,
+} from "~/db/schema";
+
+/**
+ * Build the full "your data" export bundle for a user — every vehicle, log,
+ * reading, vendor, tag, part, and document they own. Shared by the
+ * `/account/export` download endpoint and the Google Drive sync, so the JSON
+ * written to Drive is byte-for-byte the same as the manual download. Returns
+ * null when the user no longer exists.
+ */
+export async function buildUserExport(userId: string) {
+  const db = await getDb();
+  const [user] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      createdAt: users.createdAt,
+      updatedAt: users.updatedAt,
+    })
+    .from(users)
+    .where(eq(users.id, userId));
+
+  if (!user) return null;
+
+  const [userVehicles, userLogs] = await Promise.all([
+    db.select().from(vehicles).where(eq(vehicles.userId, userId)),
+    db.select().from(logs).where(eq(logs.userId, userId)),
+  ]);
+
+  const logIds = userLogs.map((l) => l.id);
+  const vehicleIds = userVehicles.map((v) => v.id);
+  const mechanicIds = Array.from(
+    new Set(
+      userLogs.map((l) => l.mechanicId).filter((id): id is string => !!id),
+    ),
+  );
+
+  const [tagJoins, partJoins, mechanicRows, readingRows, documentRows] =
+    await Promise.all([
+      logIds.length
+        ? db.select().from(logsToTags).where(inArray(logsToTags.logId, logIds))
+        : Promise.resolve([]),
+      logIds.length
+        ? db
+            .select()
+            .from(logsToParts)
+            .where(inArray(logsToParts.logId, logIds))
+        : Promise.resolve([]),
+      mechanicIds.length
+        ? db.select().from(mechanics).where(inArray(mechanics.id, mechanicIds))
+        : Promise.resolve([]),
+      vehicleIds.length
+        ? db
+            .select()
+            .from(odometerReadings)
+            .where(inArray(odometerReadings.vehicleId, vehicleIds))
+        : Promise.resolve([]),
+      vehicleIds.length
+        ? db
+            .select()
+            .from(vehicleDocuments)
+            .where(inArray(vehicleDocuments.vehicleId, vehicleIds))
+        : Promise.resolve([]),
+    ]);
+
+  const tagIds = Array.from(new Set(tagJoins.map((j) => j.tagId)));
+  const partIds = Array.from(new Set(partJoins.map((j) => j.partId)));
+
+  const [tagRows, partRows] = await Promise.all([
+    tagIds.length
+      ? db.select().from(tags).where(inArray(tags.id, tagIds))
+      : Promise.resolve([]),
+    partIds.length
+      ? db.select().from(parts).where(inArray(parts.id, partIds))
+      : Promise.resolve([]),
+  ]);
+
+  return {
+    schemaVersion: 1 as const,
+    exportedAt: new Date().toISOString(),
+    user,
+    vehicles: userVehicles.map((v) => ({
+      ...v,
+      avatarUrl: v.avatarPath ? `/files/${v.avatarPath}` : null,
+    })),
+    logs: userLogs,
+    odometerReadings: readingRows,
+    vehicleDocuments: documentRows.map((d) => ({
+      ...d,
+      fileUrl: `/files/${d.path}`,
+    })),
+    mechanics: mechanicRows,
+    tags: tagRows,
+    parts: partRows,
+    logsToTags: tagJoins,
+    logsToParts: partJoins,
+  };
+}

--- a/app/models/google-drive.server.ts
+++ b/app/models/google-drive.server.ts
@@ -1,0 +1,463 @@
+import { and, eq } from "drizzle-orm";
+
+import { type DrizzleClient, getDb } from "~/db/client";
+import type {
+  GoogleConnection,
+  Log,
+  LogAttachment,
+  Vehicle,
+  VehicleDocument,
+} from "~/db/schema";
+import {
+  driveSyncedFiles,
+  googleConnections,
+  logAttachments,
+  logs,
+  vehicleDocuments,
+  vehicles,
+} from "~/db/schema";
+import { decryptSecret, encryptSecret } from "~/google/crypto.server";
+import {
+  createFolder,
+  fileExists,
+  updateFileContent,
+  uploadFile,
+} from "~/google/drive.server";
+import {
+  type GoogleTokens,
+  isGoogleDriveConfigured,
+  refreshAccessToken,
+  revokeToken,
+} from "~/google/oauth.server";
+import { buildUserExport } from "~/models/export.server";
+import { getStorage } from "~/storage.server";
+
+/** What changed in a single sync run, surfaced to the user. */
+export type DriveSyncSummary = {
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  errors: string[];
+};
+
+/** Connection state for the profile UI. */
+export type DriveConnectionStatus = {
+  /** Server has Google OAuth credentials configured. */
+  configured: boolean;
+  connected: boolean;
+  googleEmail: string | null;
+  lastSyncedAt: Date | null;
+};
+
+const ROOT_FOLDER_NAME = "Logbook";
+const EXPORT_FILE_NAME = "logbook-export.json";
+/** Refresh the access token a minute before it actually expires. */
+const TOKEN_REFRESH_MARGIN_MS = 60_000;
+
+export async function getConnection(
+  userId: string,
+): Promise<GoogleConnection | null> {
+  const db = await getDb();
+  const [row] = await db
+    .select()
+    .from(googleConnections)
+    .where(eq(googleConnections.userId, userId));
+  return row ?? null;
+}
+
+export async function getDriveConnectionStatus(
+  userId: string,
+): Promise<DriveConnectionStatus> {
+  const connection = await getConnection(userId);
+  return {
+    configured: isGoogleDriveConfigured(),
+    connected: Boolean(connection),
+    googleEmail: connection?.googleEmail ?? null,
+    lastSyncedAt: connection?.lastSyncedAt ?? null,
+  };
+}
+
+/**
+ * Persist a freshly-authorized connection. Google only returns a refresh token
+ * on the first consent of a grant; on reconnect we keep the existing one if a
+ * new one isn't supplied (we force `prompt=consent` so this is belt-and-braces).
+ */
+export async function saveConnectionFromTokens({
+  userId,
+  tokens,
+}: {
+  userId: string;
+  tokens: GoogleTokens;
+}): Promise<void> {
+  const db = await getDb();
+  const existing = await getConnection(userId);
+  const refreshToken =
+    tokens.refreshToken ??
+    (existing ? await decryptSecret(existing.refreshTokenEnc) : null);
+  if (!refreshToken) {
+    throw new Error(
+      "Google did not return a refresh token. Remove Logbook from your Google account's third-party access and reconnect.",
+    );
+  }
+
+  const refreshTokenEnc = await encryptSecret(refreshToken);
+  const accessTokenExpiresAt = new Date(
+    Date.now() + tokens.expiresInSeconds * 1000,
+  );
+  const values = {
+    userId,
+    googleEmail: tokens.email ?? existing?.googleEmail ?? null,
+    refreshTokenEnc,
+    accessToken: tokens.accessToken,
+    accessTokenExpiresAt,
+    scope: tokens.scope,
+  };
+  await db
+    .insert(googleConnections)
+    .values(values)
+    .onConflictDoUpdate({
+      target: googleConnections.userId,
+      set: {
+        googleEmail: values.googleEmail,
+        refreshTokenEnc,
+        accessToken: tokens.accessToken,
+        accessTokenExpiresAt,
+        scope: tokens.scope,
+      },
+    });
+}
+
+/**
+ * Disconnect: revoke the grant at Google (best-effort) and drop the local
+ * connection plus its file mappings. Re-syncing after a reconnect rebuilds the
+ * mappings (it will re-upload, since the prior Drive files are now orphaned).
+ */
+export async function disconnectDrive(userId: string): Promise<void> {
+  const db = await getDb();
+  const connection = await getConnection(userId);
+  if (connection) {
+    try {
+      await revokeToken(await decryptSecret(connection.refreshTokenEnc));
+    } catch {
+      // The local rows go regardless; a failed remote revoke is harmless.
+    }
+  }
+  await db
+    .delete(googleConnections)
+    .where(eq(googleConnections.userId, userId));
+  await db.delete(driveSyncedFiles).where(eq(driveSyncedFiles.userId, userId));
+}
+
+/** A valid access token, refreshing (and caching) via the stored refresh token. */
+async function getValidAccessToken(
+  connection: GoogleConnection,
+): Promise<string> {
+  if (
+    connection.accessToken &&
+    connection.accessTokenExpiresAt &&
+    connection.accessTokenExpiresAt.getTime() - TOKEN_REFRESH_MARGIN_MS >
+      Date.now()
+  ) {
+    return connection.accessToken;
+  }
+
+  const refreshToken = await decryptSecret(connection.refreshTokenEnc);
+  const { accessToken, expiresInSeconds } =
+    await refreshAccessToken(refreshToken);
+  const db = await getDb();
+  await db
+    .update(googleConnections)
+    .set({
+      accessToken,
+      accessTokenExpiresAt: new Date(Date.now() + expiresInSeconds * 1000),
+    })
+    .where(eq(googleConnections.userId, connection.userId));
+  return accessToken;
+}
+
+type SyncContext = {
+  db: DrizzleClient;
+  userId: string;
+  accessToken: string;
+  summary: DriveSyncSummary;
+};
+
+/**
+ * Push the user's documents, scan/photo attachments, and a JSON data export
+ * into a "Logbook" folder in their Google Drive. One-way (app → Drive) and
+ * idempotent: immutable blobs already mapped in `drive_synced_files` are
+ * skipped, folders are reused, and the export is updated in place.
+ *
+ * Note: this runs synchronously within the request. For a very large backlog
+ * it could approach Workers' wall-clock limit — but the mapping table makes a
+ * re-run resume where it left off, so a partial sync is safe to repeat.
+ */
+export async function syncToDrive(userId: string): Promise<DriveSyncSummary> {
+  const db = await getDb();
+  const connection = await getConnection(userId);
+  if (!connection) throw new Error("Google Drive is not connected");
+
+  const accessToken = await getValidAccessToken(connection);
+  const summary: DriveSyncSummary = {
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    failed: 0,
+    errors: [],
+  };
+  const ctx: SyncContext = { db, userId, accessToken, summary };
+
+  const rootId = await ensureFolder(ctx, "root", ROOT_FOLDER_NAME);
+  if (connection.rootFolderId !== rootId) {
+    await db
+      .update(googleConnections)
+      .set({ rootFolderId: rootId })
+      .where(eq(googleConnections.userId, userId));
+  }
+
+  // Owned vehicles only — matches the "your data" export's ownership scope, so
+  // we never copy a shared vehicle's records into someone else's Drive.
+  const ownedVehicles = await db
+    .select()
+    .from(vehicles)
+    .where(eq(vehicles.userId, userId));
+
+  for (const vehicle of ownedVehicles) {
+    const vehicleFolderId = await ensureFolder(
+      ctx,
+      `vehicle:${vehicle.id}`,
+      vehicleFolderName(vehicle),
+      rootId,
+    );
+
+    const docs = await db
+      .select()
+      .from(vehicleDocuments)
+      .where(eq(vehicleDocuments.vehicleId, vehicle.id));
+    if (docs.length > 0) {
+      const docsFolder = await ensureFolder(
+        ctx,
+        `vehicle:${vehicle.id}:documents`,
+        "Documents",
+        vehicleFolderId,
+      );
+      for (const doc of docs) {
+        await syncBlob(
+          ctx,
+          "vehicle_document",
+          doc.id,
+          docsFolder,
+          documentFileName(doc),
+          doc.path,
+        );
+      }
+    }
+
+    const attachmentRows = await db
+      .select({ att: logAttachments, log: logs })
+      .from(logAttachments)
+      .innerJoin(logs, eq(logs.id, logAttachments.logId))
+      .where(eq(logs.vehicleId, vehicle.id));
+    if (attachmentRows.length > 0) {
+      const serviceFolder = await ensureFolder(
+        ctx,
+        `vehicle:${vehicle.id}:service`,
+        "Service Records",
+        vehicleFolderId,
+      );
+      for (const { att, log } of attachmentRows) {
+        await syncBlob(
+          ctx,
+          "log_attachment",
+          att.id,
+          serviceFolder,
+          attachmentFileName(log, att),
+          att.path,
+        );
+      }
+    }
+  }
+
+  await syncExport(ctx, rootId);
+
+  await db
+    .update(googleConnections)
+    .set({ lastSyncedAt: new Date() })
+    .where(eq(googleConnections.userId, userId));
+  return summary;
+}
+
+/** Create-or-reuse a Drive folder, recovering if a mapped folder was deleted. */
+async function ensureFolder(
+  ctx: SyncContext,
+  sourceKey: string,
+  name: string,
+  parentId?: string,
+): Promise<string> {
+  const existing = await getMapping(ctx, "folder", sourceKey);
+  if (existing) {
+    // If the existence check itself fails (transient), assume it's there
+    // rather than risk creating a duplicate folder.
+    const stillThere = await fileExists({
+      accessToken: ctx.accessToken,
+      fileId: existing,
+    }).catch(() => true);
+    if (stillThere) return existing;
+  }
+  const id = await createFolder({
+    accessToken: ctx.accessToken,
+    name,
+    parentId,
+  });
+  await recordMapping(ctx, "folder", sourceKey, id);
+  return id;
+}
+
+/** Upload one immutable blob if it hasn't been synced before; else skip. */
+async function syncBlob(
+  ctx: SyncContext,
+  sourceType: "vehicle_document" | "log_attachment",
+  sourceKey: string,
+  folderId: string,
+  name: string,
+  storagePath: string,
+): Promise<void> {
+  if (await getMapping(ctx, sourceType, sourceKey)) {
+    ctx.summary.skipped++;
+    return;
+  }
+  const file = await getStorage().read(storagePath);
+  if (!file) {
+    ctx.summary.failed++;
+    ctx.summary.errors.push(`Missing stored file for "${name}"`);
+    return;
+  }
+  try {
+    const id = await uploadFile({
+      accessToken: ctx.accessToken,
+      name,
+      mimeType: file.contentType,
+      body: file.body,
+      parentId: folderId,
+    });
+    await recordMapping(ctx, sourceType, sourceKey, id);
+    ctx.summary.created++;
+  } catch (err) {
+    ctx.summary.failed++;
+    ctx.summary.errors.push(`${name}: ${errorMessage(err)}`);
+  }
+}
+
+/** Write (or refresh) the JSON data export at the Logbook root. */
+async function syncExport(ctx: SyncContext, rootId: string): Promise<void> {
+  const data = await buildUserExport(ctx.userId);
+  if (!data) return;
+  const body = new TextEncoder().encode(JSON.stringify(data, null, 2));
+  const existing = await getMapping(ctx, "export", "export");
+
+  if (existing) {
+    try {
+      await updateFileContent({
+        accessToken: ctx.accessToken,
+        fileId: existing,
+        mimeType: "application/json",
+        body,
+      });
+      ctx.summary.updated++;
+      return;
+    } catch {
+      // The export file was likely deleted in Drive — fall through and
+      // recreate it, replacing the stale mapping below.
+    }
+  }
+
+  try {
+    const id = await uploadFile({
+      accessToken: ctx.accessToken,
+      name: EXPORT_FILE_NAME,
+      mimeType: "application/json",
+      body,
+      parentId: rootId,
+    });
+    await recordMapping(ctx, "export", "export", id);
+    ctx.summary.created++;
+  } catch (err) {
+    ctx.summary.failed++;
+    ctx.summary.errors.push(`${EXPORT_FILE_NAME}: ${errorMessage(err)}`);
+  }
+}
+
+async function getMapping(
+  ctx: SyncContext,
+  sourceType: string,
+  sourceKey: string,
+): Promise<string | null> {
+  const [row] = await ctx.db
+    .select({ driveFileId: driveSyncedFiles.driveFileId })
+    .from(driveSyncedFiles)
+    .where(
+      and(
+        eq(driveSyncedFiles.userId, ctx.userId),
+        eq(driveSyncedFiles.sourceType, sourceType),
+        eq(driveSyncedFiles.sourceKey, sourceKey),
+      ),
+    );
+  return row?.driveFileId ?? null;
+}
+
+async function recordMapping(
+  ctx: SyncContext,
+  sourceType: string,
+  sourceKey: string,
+  driveFileId: string,
+): Promise<void> {
+  await ctx.db
+    .insert(driveSyncedFiles)
+    .values({ userId: ctx.userId, sourceType, sourceKey, driveFileId })
+    .onConflictDoUpdate({
+      target: [
+        driveSyncedFiles.userId,
+        driveSyncedFiles.sourceType,
+        driveSyncedFiles.sourceKey,
+      ],
+      set: { driveFileId, syncedAt: new Date() },
+    });
+}
+
+function vehicleFolderName(vehicle: Vehicle): string {
+  const base = [vehicle.year, vehicle.make, vehicle.model, vehicle.trim]
+    .filter(Boolean)
+    .join(" ");
+  const named = vehicle.name?.trim()
+    ? `${vehicle.name.trim()} (${base})`
+    : base;
+  return named.trim() || "Vehicle";
+}
+
+function documentFileName(doc: VehicleDocument): string {
+  if (doc.originalName) return doc.originalName;
+  const base = doc.label?.trim() || doc.kind || "document";
+  return `${base}${extensionFor(doc.contentType)}`;
+}
+
+function attachmentFileName(log: Log, att: LogAttachment): string {
+  const date = log.servicedAt ? log.servicedAt.toISOString().slice(0, 10) : "";
+  const label = [date, log.title].filter(Boolean).join(" ").trim();
+  if (att.originalName) {
+    return label ? `${label} - ${att.originalName}` : att.originalName;
+  }
+  return `${label || "scan"}${extensionFor(att.contentType)}`;
+}
+
+function extensionFor(contentType: string): string {
+  if (contentType === "image/jpeg") return ".jpg";
+  if (contentType === "image/png") return ".png";
+  if (contentType === "image/webp") return ".webp";
+  if (contentType === "application/pdf") return ".pdf";
+  return "";
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/app/routes/_authed.profile.tsx
+++ b/app/routes/_authed.profile.tsx
@@ -4,6 +4,13 @@ import { createServerFn } from "@tanstack/react-start";
 import { useEffect, useState } from "react";
 import { requireAuth } from "~/auth/session.server";
 import { btnSecondary, card } from "~/components/ui";
+import {
+  type DriveConnectionStatus,
+  type DriveSyncSummary,
+  disconnectDrive,
+  getDriveConnectionStatus,
+  syncToDrive,
+} from "~/models/google-drive.server";
 import { changePassword, updateUser } from "~/models/user.server";
 import { getStorage } from "~/storage.server";
 
@@ -70,12 +77,38 @@ const changePasswordFn = createServerFn({ method: "POST" })
     return { success: true as const };
   });
 
+const getDriveStatusFn = createServerFn({ method: "GET" }).handler(async () => {
+  const userId = await requireAuth();
+  return getDriveConnectionStatus(userId);
+});
+
+const syncDriveFn = createServerFn({ method: "POST" }).handler(
+  async (): Promise<{ summary: DriveSyncSummary } | { error: string }> => {
+    const userId = await requireAuth();
+    try {
+      return { summary: await syncToDrive(userId) };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : "Sync failed" };
+    }
+  },
+);
+
+const disconnectDriveFn = createServerFn({ method: "POST" }).handler(
+  async () => {
+    const userId = await requireAuth();
+    await disconnectDrive(userId);
+    return { success: true as const };
+  },
+);
+
 export const Route = createFileRoute("/_authed/profile")({
+  loader: async () => ({ drive: await getDriveStatusFn() }),
   component: ProfilePage,
 });
 
 function ProfilePage() {
   const { user } = Route.useRouteContext();
+  const { drive } = Route.useLoaderData();
 
   return (
     <section className="space-y-10">
@@ -86,8 +119,164 @@ function ProfilePage() {
       <hr className="border-slate-200" />
       <ConnectClaude />
       <hr className="border-slate-200" />
+      <GoogleDrive status={drive} />
+      <hr className="border-slate-200" />
       <YourData />
     </section>
+  );
+}
+
+function GoogleDrive({ status }: { status: DriveConnectionStatus }) {
+  const router = useRouter();
+  const [banner, setBanner] = useState<string | null>(null);
+  const [pending, setPending] = useState<null | "sync" | "disconnect">(null);
+  const [result, setResult] = useState<DriveSyncSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Surface the ?drive=… outcome from the OAuth redirect, then strip it from
+  // the URL so a refresh doesn't re-show the banner.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const outcome = params.get("drive");
+    if (!outcome) return;
+    setBanner(
+      {
+        connected: "Google Drive connected.",
+        denied: "Connection cancelled.",
+        unconfigured: "Google Drive sync isn't configured on this server.",
+        error: "Something went wrong connecting Google Drive. Try again.",
+      }[outcome] ?? null,
+    );
+    params.delete("drive");
+    const qs = params.toString();
+    window.history.replaceState(
+      {},
+      "",
+      window.location.pathname + (qs ? `?${qs}` : ""),
+    );
+  }, []);
+
+  async function runSync() {
+    setPending("sync");
+    setError(null);
+    setResult(null);
+    try {
+      const res = await syncDriveFn();
+      if ("error" in res) setError(res.error);
+      else {
+        setResult(res.summary);
+        await router.invalidate();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sync failed");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function disconnect() {
+    setPending("disconnect");
+    setError(null);
+    setResult(null);
+    try {
+      await disconnectDriveFn();
+      await router.invalidate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to disconnect");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  return (
+    <div>
+      <h2 className="text-lg font-medium text-slate-900">
+        ☁️ Sync to Google Drive
+      </h2>
+      <div className={`${card} mt-4 max-w-lg p-5`}>
+        <p className="text-sm text-ink-muted">
+          Keep a copy of your records in your own Google Drive. Logbook creates
+          a single <span className="font-medium text-ink">Logbook</span> folder
+          and copies your vehicle documents, receipt scans, and a full data
+          export into it. Using Google's <code>drive.file</code> access, Logbook
+          can only see files it created here — never the rest of your Drive.
+        </p>
+
+        {banner ? (
+          <p className="mt-3 rounded border border-line bg-sunken p-2 text-sm text-ink">
+            {banner}
+          </p>
+        ) : null}
+
+        {!status.configured ? (
+          <p className="mt-4 text-sm text-ink-muted">
+            Google Drive sync isn't configured on this server.
+          </p>
+        ) : status.connected ? (
+          <div className="mt-4 space-y-3">
+            <p className="text-sm text-ink">
+              Connected
+              {status.googleEmail ? (
+                <>
+                  {" as "}
+                  <span className="font-medium">{status.googleEmail}</span>
+                </>
+              ) : null}
+              .
+            </p>
+            <p className="text-xs text-ink-muted">
+              {status.lastSyncedAt
+                ? `Last synced ${new Date(status.lastSyncedAt).toLocaleString()}`
+                : "Not synced yet."}
+            </p>
+
+            {error ? (
+              <p className="rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
+                {error}
+              </p>
+            ) : null}
+            {result ? (
+              <p className="rounded border border-green-200 bg-green-50 p-2 text-sm text-green-700">
+                Synced: {result.created} added, {result.updated} updated,{" "}
+                {result.skipped} already current
+                {result.failed > 0 ? `, ${result.failed} failed` : ""}.
+                {result.errors.length > 0 ? (
+                  <span className="mt-1 block text-xs text-red-700">
+                    {result.errors.slice(0, 5).join("; ")}
+                  </span>
+                ) : null}
+              </p>
+            ) : null}
+
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={runSync}
+                disabled={pending !== null}
+                className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {pending === "sync" ? "Syncing…" : "Sync now"}
+              </button>
+              <button
+                type="button"
+                onClick={disconnect}
+                disabled={pending !== null}
+                className={btnSecondary}
+              >
+                {pending === "disconnect" ? "Disconnecting…" : "Disconnect"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <a
+            href="/auth/google/start"
+            className="mt-4 inline-block rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+          >
+            Connect Google Drive
+          </a>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/app/routes/account.export.tsx
+++ b/app/routes/account.export.tsx
@@ -1,20 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { eq, inArray } from "drizzle-orm";
 
 import { useAppSession } from "~/auth/session.server";
-import { getDb } from "~/db/client";
-import {
-  logs,
-  logsToParts,
-  logsToTags,
-  mechanics,
-  odometerReadings,
-  parts,
-  tags,
-  users,
-  vehicleDocuments,
-  vehicles,
-} from "~/db/schema";
+import { buildUserExport } from "~/models/export.server";
 
 export const Route = createFileRoute("/account/export")({
   server: {
@@ -24,104 +11,12 @@ export const Route = createFileRoute("/account/export")({
         const userId = session.data.userId;
         if (!userId) return new Response("Unauthorized", { status: 401 });
 
-        const db = await getDb();
-        const [user] = await db
-          .select({
-            id: users.id,
-            email: users.email,
-            createdAt: users.createdAt,
-            updatedAt: users.updatedAt,
-          })
-          .from(users)
-          .where(eq(users.id, userId));
-
-        if (!user) return new Response("Not found", { status: 404 });
-
-        const [userVehicles, userLogs] = await Promise.all([
-          db.select().from(vehicles).where(eq(vehicles.userId, userId)),
-          db.select().from(logs).where(eq(logs.userId, userId)),
-        ]);
-
-        const logIds = userLogs.map((l) => l.id);
-        const vehicleIds = userVehicles.map((v) => v.id);
-        const mechanicIds = Array.from(
-          new Set(
-            userLogs
-              .map((l) => l.mechanicId)
-              .filter((id): id is string => !!id),
-          ),
-        );
-
-        const [tagJoins, partJoins, mechanicRows, readingRows, documentRows] =
-          await Promise.all([
-            logIds.length
-              ? db
-                  .select()
-                  .from(logsToTags)
-                  .where(inArray(logsToTags.logId, logIds))
-              : Promise.resolve([]),
-            logIds.length
-              ? db
-                  .select()
-                  .from(logsToParts)
-                  .where(inArray(logsToParts.logId, logIds))
-              : Promise.resolve([]),
-            mechanicIds.length
-              ? db
-                  .select()
-                  .from(mechanics)
-                  .where(inArray(mechanics.id, mechanicIds))
-              : Promise.resolve([]),
-            vehicleIds.length
-              ? db
-                  .select()
-                  .from(odometerReadings)
-                  .where(inArray(odometerReadings.vehicleId, vehicleIds))
-              : Promise.resolve([]),
-            vehicleIds.length
-              ? db
-                  .select()
-                  .from(vehicleDocuments)
-                  .where(inArray(vehicleDocuments.vehicleId, vehicleIds))
-              : Promise.resolve([]),
-          ]);
-
-        const tagIds = Array.from(new Set(tagJoins.map((j) => j.tagId)));
-        const partIds = Array.from(new Set(partJoins.map((j) => j.partId)));
-
-        const [tagRows, partRows] = await Promise.all([
-          tagIds.length
-            ? db.select().from(tags).where(inArray(tags.id, tagIds))
-            : Promise.resolve([]),
-          partIds.length
-            ? db.select().from(parts).where(inArray(parts.id, partIds))
-            : Promise.resolve([]),
-        ]);
-
-        const body = {
-          schemaVersion: 1 as const,
-          exportedAt: new Date().toISOString(),
-          user,
-          vehicles: userVehicles.map((v) => ({
-            ...v,
-            avatarUrl: v.avatarPath ? `/files/${v.avatarPath}` : null,
-          })),
-          logs: userLogs,
-          odometerReadings: readingRows,
-          vehicleDocuments: documentRows.map((d) => ({
-            ...d,
-            fileUrl: `/files/${d.path}`,
-          })),
-          mechanics: mechanicRows,
-          tags: tagRows,
-          parts: partRows,
-          logsToTags: tagJoins,
-          logsToParts: partJoins,
-        };
+        const body = await buildUserExport(userId);
+        if (!body) return new Response("Not found", { status: 404 });
 
         return Response.json(body, {
           headers: {
-            "content-disposition": `attachment; filename="logbook-${user.email}.json"`,
+            "content-disposition": `attachment; filename="logbook-${body.user.email}.json"`,
           },
         });
       },

--- a/app/routes/auth.google.callback.tsx
+++ b/app/routes/auth.google.callback.tsx
@@ -1,0 +1,52 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { useAppSession } from "~/auth/session.server";
+import { exchangeCode } from "~/google/oauth.server";
+import { verifyState } from "~/google/state.server";
+import { saveConnectionFromTokens } from "~/models/google-drive.server";
+
+function redirect(location: string): Response {
+  return new Response(null, { status: 302, headers: { location } });
+}
+
+/**
+ * Google redirects back here after consent. We verify the signed `state`
+ * against the current session, exchange the code for tokens, and persist the
+ * (encrypted) connection. All outcomes land back on /profile with a `drive`
+ * status the UI turns into a banner.
+ */
+export const Route = createFileRoute("/auth/google/callback")({
+  server: {
+    handlers: {
+      GET: async ({ request }: { request: Request }) => {
+        const session = await useAppSession();
+        const userId = session.data.userId;
+        if (!userId) {
+          return redirect(
+            `/login?redirectTo=${encodeURIComponent("/profile")}`,
+          );
+        }
+
+        const url = new URL(request.url);
+        if (url.searchParams.get("error")) {
+          return redirect("/profile?drive=denied");
+        }
+
+        const code = url.searchParams.get("code");
+        const state = url.searchParams.get("state");
+        if (!code || !(await verifyState(state, userId))) {
+          return redirect("/profile?drive=error");
+        }
+
+        try {
+          const redirectUri = `${url.origin}/auth/google/callback`;
+          const tokens = await exchangeCode({ code, redirectUri });
+          await saveConnectionFromTokens({ userId, tokens });
+          return redirect("/profile?drive=connected");
+        } catch {
+          return redirect("/profile?drive=error");
+        }
+      },
+    },
+  },
+});

--- a/app/routes/auth.google.start.tsx
+++ b/app/routes/auth.google.start.tsx
@@ -1,0 +1,38 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { useAppSession } from "~/auth/session.server";
+import { buildAuthUrl, isGoogleDriveConfigured } from "~/google/oauth.server";
+import { createState } from "~/google/state.server";
+
+function redirect(location: string): Response {
+  return new Response(null, { status: 302, headers: { location } });
+}
+
+/**
+ * Kick off the Google Drive connect flow: bounce the signed-in user to
+ * Google's consent screen with a signed `state` and a redirect URI derived
+ * from the current origin (so dev and prod each work without configuration).
+ */
+export const Route = createFileRoute("/auth/google/start")({
+  server: {
+    handlers: {
+      GET: async ({ request }: { request: Request }) => {
+        const session = await useAppSession();
+        const userId = session.data.userId;
+        if (!userId) {
+          return redirect(
+            `/login?redirectTo=${encodeURIComponent("/profile")}`,
+          );
+        }
+        if (!isGoogleDriveConfigured()) {
+          return redirect("/profile?drive=unconfigured");
+        }
+
+        const url = new URL(request.url);
+        const redirectUri = `${url.origin}/auth/google/callback`;
+        const state = await createState(userId);
+        return redirect(buildAuthUrl({ redirectUri, state }));
+      },
+    },
+  },
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -68,4 +68,12 @@
   ]
   // SESSION_SECRET is a Wrangler secret. Set with:
   //   wrangler secret put SESSION_SECRET
+  //
+  // Google Drive sync (optional) is configured via Wrangler secrets too —
+  // when unset, the feature stays hidden/disabled. Create an OAuth 2.0 "Web
+  // application" client in Google Cloud Console with the Drive API enabled and
+  // redirect URI https://<your-domain>/auth/google/callback, then:
+  //   wrangler secret put GOOGLE_OAUTH_CLIENT_ID
+  //   wrangler secret put GOOGLE_OAUTH_CLIENT_SECRET
+  //   wrangler secret put GOOGLE_TOKEN_KEY     # openssl rand -base64 32
 }


### PR DESCRIPTION
## What

Lets users connect their own Google Drive and sync their **vehicle documents**, **receipt scans/photos**, and a **full JSON data export** into a single app-managed `Logbook` folder. One-way (app → Drive), triggered by a manual **Sync now** button on the Profile page.

## Access model — strict, app-scoped

Uses Google's **`drive.file`** scope, the least-privilege Drive scope: Logbook can only see and modify files **it created**. It cannot list, read, or touch anything else in the user's Drive. Everything lives in one `Logbook` folder, organized per vehicle (`Documents` + `Service Records` subfolders) with the JSON export at the root.

Here Logbook is the OAuth **client** (the opposite role from the MCP server, where it's the provider).

## Design notes

- **Idempotent & resumable** via `drive_synced_files` (a source → Drive-id map): already-uploaded blobs are skipped, folders reused, the export updated in place — a partial sync is safe to re-run.
- **Owned-vehicles only**, matching the existing `/account/export` ownership scope. `buildUserExport` was extracted to `app/models/export.server.ts` and is now shared by the export route and the sync (one source of truth).
- **Runtime-agnostic**: raw `fetch` (no `googleapis` SDK), credentials from `process.env` like `SESSION_SECRET` — runs on Workers and Node self-host, **no new wrangler binding**.
- **Security**: refresh tokens AES-GCM encrypted at rest (`GOOGLE_TOKEN_KEY`); OAuth `state` is HMAC-signed and bound to the user (stateless, no session write in raw handlers); disconnect revokes the grant at Google.

## Schema

New migration `0008`:
- `google_connections` — per-user tokens (encrypted refresh token, cached access token, root folder id, last-synced).
- `drive_synced_files` — idempotent sync map, unique on `(user, source_type, source_key)`.

## Setup (operator)

Feature stays hidden until configured. Create a Google Cloud OAuth 2.0 **Web application** client (Drive API enabled, scope `.../auth/drive.file`, redirect URI `https://<domain>/auth/google/callback` + `http://localhost:3000/...` for dev), then set `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `GOOGLE_TOKEN_KEY` (Wrangler secrets on CF / env vars on Node). Docs in `README.md`, `.env.example`, `wrangler.jsonc`.

## Testing

- `npm run validate` green: typecheck + lint + **91/91 tests** (8 new unit tests for the crypto round-trip and signed state).
- `npm run build` (Cloudflare Workers) succeeds — server modules bundle cleanly past SSR import-protection.
- ⚠️ The **live OAuth round-trip wasn't exercised** (no Google credentials in the dev environment). The token/crypto/state logic is unit-tested and everything builds, but a real connect + sync should be smoke-tested once a Google client is configured.

## Caveat

Sync runs in a single request; a very large backlog could approach Workers' wall-clock limit. The mapping table makes re-runs resume safely. Flagged in a code comment — a queue/Durable Object is the path if it ever bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)