### PR TITLE
feat: RigFile branding — brand mark, dark-mode fix, AI-neutral home/account

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,14 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
   `prefers-color-scheme`) — raw slate/red classes won't reskin. The brand
   mark is `app/components/Logo.tsx` (folder + car silhouette, `currentColor`).
   Shared class recipes live in `app/components/ui.ts`.
+- **Branded error + not-found pages.** The root route (`__root.tsx`) sets
+  `errorComponent` and `notFoundComponent` to render `ErrorState`
+  (`app/components/ErrorState.tsx` — a sad broken-down car) inside the document
+  shell; `RootDocument` takes `children` so the same `<html>` shell wraps the
+  normal, error, and not-found views. Public-route loaders (e.g. `/`) must not
+  hard-depend on a DB/session lookup — wrap `getCurrentUserFn()` in try/catch
+  and degrade to the logged-out view so a stale cookie or DB blip can't crash
+  the page.
 - **Dev server env comes from `.dev.vars`**, not the host process env —
   the Cloudflare vite plugin runs SSR in workerd, which can't see shell
   exports. Node-side tooling (drizzle-kit, seed, vitest) still reads

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,9 +91,13 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
 - **Semantic color tokens, not raw palette classes** in app UI: use
   `bg-surface`/`bg-card`/`bg-sunken`, `text-ink`/`text-ink-muted`,
   `border-line`, `bg-accent`, `text-danger`/`warn`/`ok` (defined via
-  `@theme inline` in `app/styles.css`). Garage Mode toggles a `.garage`
-  class on `<html>` (high-contrast dark + 18px base font) — raw slate/red
-  classes won't reskin. Shared class recipes live in `app/components/ui.ts`.
+  `@theme inline` in `app/styles.css`). Dark mode toggles a `.dark` class on
+  `<html>` (palette swap only — no font-size change, so the layout never
+  shifts; `ThemeToggle` in `_authed.tsx` persists `rigfile-theme`, and a
+  pre-paint script in `__root.tsx` applies it / falls back to the OS
+  `prefers-color-scheme`) — raw slate/red classes won't reskin. The brand
+  mark is `app/components/Logo.tsx` (folder + car silhouette, `currentColor`).
+  Shared class recipes live in `app/components/ui.ts`.
 - **Dev server env comes from `.dev.vars`**, not the host process env —
   the Cloudflare vite plugin runs SSR in workerd, which can't see shell
   exports. Node-side tooling (drizzle-kit, seed, vitest) still reads

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # RigFile
 
-A personal maintenance log for every car you own. Track services, parts,
-odometer, cost, and notes per vehicle. Export your whole history as JSON
-whenever you want — and run your own instance on a single `docker run` if you
-don't want to rely on any hosted provider.
+**Every vehicle's file.**
+
+A home for everything about the vehicles you own — service history, receipts,
+documents, parts, odometer, cost, and notes, for every rig (car, truck, camper
+van, motorcycle, whatever you drive). Not a walled app but a record you control:
+export your whole history as JSON whenever you want, sync it to your own Google
+Drive, talk to it from Claude, and run your own instance on a single
+`docker run` if you don't want to rely on any hosted provider.
 
 What it does today:
 
@@ -43,9 +47,10 @@ What it does today:
   JPEG) before upload, so 12 MB phone shots arrive as a few hundred KB.
   (HEIC works in Safari, which can decode it; other browsers fall back to
   the original file and the server's 2MB cap applies.)
-- **Garage Mode** — one tap flips the whole app to a high-contrast dark
-  theme with bigger type and fat touch targets, for reading at arm's
-  length under bad shop lighting. Mobile-first throughout.
+- **Dark mode** — one tap flips the whole app between a light and a
+  high-contrast dark palette (and it follows your OS preference until you
+  choose). Color only — the layout never shifts. Mobile-first throughout,
+  with fat touch targets for greasy-thumb use at arm's length.
 
 This repo originally ran on Remix + Fly + Postgres + MinIO. It was rebuilt
 from the ground up in 2026 on a TanStack Start stack targeting Cloudflare

--- a/app/components/ErrorState.tsx
+++ b/app/components/ErrorState.tsx
@@ -1,0 +1,80 @@
+import { Link } from "@tanstack/react-router";
+
+import { btnPrimary, btnSecondary } from "~/components/ui";
+
+/** A broken-down little car — flat tire, sad face — for error/not-found pages. */
+function SadCar({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 64 46"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      {/* body */}
+      <path
+        d="M8 34 L8 25 L18 25 L24 18 L38 18 L44 25 L56 25 L56 34 Z"
+        fill="currentColor"
+        fillOpacity="0.1"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+      />
+      {/* window */}
+      <path
+        d="M20 24 L24 19.5 L32 19.5 L32 24 Z"
+        fill="currentColor"
+        fillOpacity="0.2"
+      />
+      {/* sad face */}
+      <circle cx="25" cy="29" r="1" fill="currentColor" />
+      <circle cx="31" cy="29" r="1" fill="currentColor" />
+      <path
+        d="M24 32.5 Q28 30 32 32.5"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+      {/* wheels — the front one is flat */}
+      <circle cx="18" cy="35" r="4" stroke="currentColor" strokeWidth="2.5" />
+      <ellipse
+        cx="46"
+        cy="36.3"
+        rx="4"
+        ry="2.3"
+        stroke="currentColor"
+        strokeWidth="2.5"
+      />
+    </svg>
+  );
+}
+
+export function ErrorState({
+  title,
+  message,
+  onReset,
+}: {
+  title: string;
+  message: string;
+  onReset?: () => void;
+}) {
+  return (
+    <main className="grid min-h-screen place-items-center bg-surface px-6 py-16">
+      <div className="max-w-md text-center">
+        <SadCar className="mx-auto h-24 w-auto text-ink-muted" />
+        <h1 className="mt-6 text-2xl font-semibold text-ink">{title}</h1>
+        <p className="mt-2 text-ink-muted">{message}</p>
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          {onReset ? (
+            <button type="button" onClick={onReset} className={btnPrimary}>
+              Try again
+            </button>
+          ) : null}
+          <Link to="/" className={onReset ? btnSecondary : btnPrimary}>
+            Go home
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/components/Logo.tsx
+++ b/app/components/Logo.tsx
@@ -1,0 +1,44 @@
+/**
+ * RigFile brand mark — a folder (filing/access) with a simple car silhouette
+ * (the rig). Single-color via `currentColor` so it inherits text color and
+ * themes for light/dark; built from primitive shapes so it stays crisp at
+ * favicon-to-hero sizes. Size it with a className (e.g. `h-6 w-6`).
+ */
+export function Logo({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      {/* folder */}
+      <path
+        d="M3 7.25c0-.83.67-1.5 1.5-1.5h3.55c.46 0 .9.21 1.18.58l.78 1.02h9.49c.83 0 1.5.67 1.5 1.5v8.4c0 .82-.67 1.5-1.5 1.5h-15c-.83 0-1.5-.68-1.5-1.5V7.25Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      {/* car body + roof */}
+      <rect
+        x="6.7"
+        y="13.1"
+        width="10.6"
+        height="2.3"
+        rx="1.1"
+        fill="currentColor"
+      />
+      <rect
+        x="9"
+        y="11.3"
+        width="5.5"
+        height="2.4"
+        rx="1.1"
+        fill="currentColor"
+      />
+      {/* wheels */}
+      <circle cx="9.5" cy="15.8" r="1.15" fill="currentColor" />
+      <circle cx="14.5" cy="15.8" r="1.15" fill="currentColor" />
+    </svg>
+  );
+}

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -7,8 +7,9 @@ import {
 
 import stylesHref from "../styles.css?url";
 
-// Applied before paint so Garage Mode doesn't flash light on reload.
-const garageModeScript = `try{if(localStorage.getItem("garage-mode")==="1")document.documentElement.classList.add("garage")}catch(e){}`;
+// Applied before paint so dark mode doesn't flash light on reload. Falls back
+// to the OS color-scheme preference when the user hasn't picked a theme.
+const themeScript = `try{var t=localStorage.getItem("rigfile-theme");if(t==="dark"||(!t&&matchMedia("(prefers-color-scheme:dark)").matches))document.documentElement.classList.add("dark")}catch(e){}`;
 
 export const Route = createRootRoute({
   head: () => ({
@@ -32,7 +33,7 @@ function RootDocument() {
       <head>
         <HeadContent />
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static inline theme script */}
-        <script dangerouslySetInnerHTML={{ __html: garageModeScript }} />
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body className="bg-surface text-ink antialiased">
         <Outlet />

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -4,7 +4,9 @@ import {
   Outlet,
   Scripts,
 } from "@tanstack/react-router";
+import type { ReactNode } from "react";
 
+import { ErrorState } from "~/components/ErrorState";
 import stylesHref from "../styles.css?url";
 
 // Applied before paint so dark mode doesn't flash light on reload. Falls back
@@ -24,10 +26,31 @@ export const Route = createRootRoute({
     ],
     links: [{ rel: "stylesheet", href: stylesHref }],
   }),
-  component: RootDocument,
+  errorComponent: ({ reset }) => (
+    <RootDocument>
+      <ErrorState
+        title="Something threw a rod"
+        message="An unexpected error stalled this page. Try again, or head back to your garage."
+        onReset={reset}
+      />
+    </RootDocument>
+  ),
+  notFoundComponent: () => (
+    <RootDocument>
+      <ErrorState
+        title="Took a wrong turn"
+        message="We couldn't find that page — it may have moved or never existed. Let's get you back on the road."
+      />
+    </RootDocument>
+  ),
+  component: () => (
+    <RootDocument>
+      <Outlet />
+    </RootDocument>
+  ),
 });
 
-function RootDocument() {
+function RootDocument({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <head>
@@ -36,7 +59,7 @@ function RootDocument() {
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body className="bg-surface text-ink antialiased">
-        <Outlet />
+        {children}
         <Scripts />
       </body>
     </html>

--- a/app/routes/_authed.profile.tsx
+++ b/app/routes/_authed.profile.tsx
@@ -119,7 +119,7 @@ function ProfilePage() {
       <hr className="border-slate-200" />
       <PasswordForm />
       <hr className="border-slate-200" />
-      <ConnectClaude />
+      <ConnectAI />
       <hr className="border-slate-200" />
       <GoogleDrive status={drive} />
       <hr className="border-slate-200" />
@@ -282,7 +282,7 @@ function GoogleDrive({ status }: { status: DriveConnectionStatus }) {
   );
 }
 
-function ConnectClaude() {
+function ConnectAI() {
   // window.location is browser-only; render the path until hydration fills
   // in the full origin.
   const [mcpUrl, setMcpUrl] = useState("/mcp");
@@ -300,23 +300,22 @@ function ConnectClaude() {
 
   return (
     <div>
-      <h2 className="text-lg font-medium text-slate-900">
-        🤖 Connect Claude (MCP)
-      </h2>
+      <h2 className="text-lg font-medium text-ink">🤖 Connect your AI (MCP)</h2>
       <div className={`${card} mt-4 max-w-lg p-5`}>
         <p className="text-sm text-ink-muted">
           RigFile is an MCP server, so you can talk to your garage from your own
-          Claude account — "what's due on the Jeep?", "log the oil change I just
-          did at 87,420 miles" — from a phone, mid-wrench. Claude signs in as{" "}
+          AI assistant — "what's due on the Jeep?", "log the oil change I just
+          did at 87,420 miles" — from a phone, mid-wrench. Your AI signs in as{" "}
           <em>you</em>: it can only see and log to vehicles your account can
           access.
         </p>
         <ol className="mt-3 list-decimal space-y-1 pl-5 text-sm text-ink-muted">
           <li>
-            In Claude (web or mobile), open{" "}
+            Open your AI client's MCP connector settings (in Claude:{" "}
             <span className="font-medium text-ink">
               Settings → Connectors → Add custom connector
             </span>
+            )
           </li>
           <li>Paste the URL below</li>
           <li>Sign in with your RigFile account and approve access</li>
@@ -335,9 +334,9 @@ function ConnectClaude() {
           </button>
         </div>
         <p className="mt-3 text-xs text-ink-muted">
-          Claude can list your vehicles, check what's due, log completed work,
+          Your AI can list your vehicles, check what's due, log completed work,
           complete reminders, and manage project parts. Connections use OAuth —
-          no API keys, and your password is never shared with Claude.
+          no API keys, and your password is never shared with the AI.
         </p>
       </div>
     </div>

--- a/app/routes/_authed.tsx
+++ b/app/routes/_authed.tsx
@@ -5,8 +5,8 @@ import {
   redirect,
 } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
-
 import { getCurrentUserFn } from "~/auth/server-fns";
+import { Logo } from "~/components/Logo";
 
 export const Route = createFileRoute("/_authed")({
   beforeLoad: async ({ location }) => {
@@ -22,19 +22,19 @@ export const Route = createFileRoute("/_authed")({
   component: AuthedLayout,
 });
 
-function GarageModeToggle() {
-  const [on, setOn] = useState(false);
+function ThemeToggle() {
+  const [dark, setDark] = useState(false);
 
   useEffect(() => {
-    setOn(document.documentElement.classList.contains("garage"));
+    setDark(document.documentElement.classList.contains("dark"));
   }, []);
 
   function toggle() {
-    const next = !on;
-    setOn(next);
-    document.documentElement.classList.toggle("garage", next);
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle("dark", next);
     try {
-      localStorage.setItem("garage-mode", next ? "1" : "0");
+      localStorage.setItem("rigfile-theme", next ? "dark" : "light");
     } catch {
       // private browsing — theme just won't persist
     }
@@ -44,16 +44,36 @@ function GarageModeToggle() {
     <button
       type="button"
       onClick={toggle}
-      aria-pressed={on}
-      title="Garage Mode: high contrast + big type for the shop"
-      className={`inline-flex min-h-11 items-center gap-2 rounded-full border px-4 text-sm font-bold tracking-wide transition-colors ${
-        on
-          ? "border-accent bg-accent text-accent-ink"
-          : "border-line bg-card text-ink-muted hover:text-ink"
-      }`}
+      aria-pressed={dark}
+      aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
+      title={dark ? "Switch to light mode" : "Switch to dark mode"}
+      className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-full border border-line bg-card text-ink-muted transition-colors hover:text-ink"
     >
-      <span aria-hidden>🔧</span>
-      <span className="hidden sm:inline">GARAGE</span>
+      {dark ? (
+        // currently dark — sun indicates a switch to light
+        <svg
+          viewBox="0 0 24 24"
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+        </svg>
+      ) : (
+        // currently light — moon indicates a switch to dark
+        <svg
+          viewBox="0 0 24 24"
+          className="h-5 w-5"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z" />
+        </svg>
+      )}
     </button>
   );
 }
@@ -72,14 +92,14 @@ function AuthedLayout() {
           >
             <span
               aria-hidden
-              className="flex h-9 w-9 items-center justify-center rounded-xl bg-accent text-lg text-accent-ink"
+              className="flex h-9 w-9 items-center justify-center rounded-xl bg-accent text-accent-ink"
             >
-              🏁
+              <Logo className="h-6 w-6" />
             </span>
             <span>RigFile</span>
           </Link>
           <div className="flex items-center gap-2">
-            <GarageModeToggle />
+            <ThemeToggle />
             <div className="relative">
               <button
                 type="button"

--- a/app/routes/_authed.vehicles.$vehicleId.projects.$projectId.tsx
+++ b/app/routes/_authed.vehicles.$vehicleId.projects.$projectId.tsx
@@ -305,7 +305,7 @@ function ProjectDetail() {
                     : "bg-sunken text-ink-muted"
               }`}
             >
-              🏁{" "}
+              🎯{" "}
               {daysUntil(project.targetDate) >= 0
                 ? `${daysUntil(project.targetDate)} days to ${formatDateOnly(project.targetDate)}`
                 : `target was ${formatDateOnly(project.targetDate)}`}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -5,7 +5,15 @@ import { Logo } from "~/components/Logo";
 import { btnPrimary, btnSecondary, card } from "~/components/ui";
 
 export const Route = createFileRoute("/")({
-  loader: async () => ({ user: await getCurrentUserFn() }),
+  // Public page: a failed/absent session must never crash it — degrade to
+  // the logged-out view if the user lookup throws (e.g. stale cookie).
+  loader: async () => {
+    try {
+      return { user: await getCurrentUserFn() };
+    } catch {
+      return { user: null };
+    }
+  },
   component: Home,
 });
 

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 
+import { Logo } from "~/components/Logo";
 import { btnPrimary, btnSecondary, card } from "~/components/ui";
 
 export const Route = createFileRoute("/")({
@@ -13,12 +14,15 @@ function Home() {
     <main className="min-h-screen bg-surface px-4 py-12 sm:px-8">
       <div className="mx-auto max-w-3xl">
         <header className="text-center">
-          <p className="text-4xl">🔧</p>
-          <h1 className="mt-2 text-4xl font-semibold text-ink">RigFile</h1>
+          <Logo className="mx-auto h-14 w-14 text-accent" />
+          <h1 className="mt-3 text-4xl font-semibold text-ink">RigFile</h1>
+          <p className="mt-1 text-lg font-medium text-ink-muted">
+            Every vehicle's file.
+          </p>
           <p className="mx-auto mt-3 max-w-xl text-lg text-ink-muted">
-            A shared maintenance log for your garage. Track service history,
-            reminders, and build projects for every vehicle — together with your
-            crew.
+            Service history, receipts, and documents for every rig you own — in
+            one place you control, accessible anywhere (even from Claude).
+            Self-hosted, open source, and yours to export.
           </p>
           <div className="mt-6 flex flex-wrap justify-center gap-3">
             <Link

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,15 +1,19 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 
+import { getCurrentUserFn } from "~/auth/server-fns";
 import { Logo } from "~/components/Logo";
 import { btnPrimary, btnSecondary, card } from "~/components/ui";
 
 export const Route = createFileRoute("/")({
+  loader: async () => ({ user: await getCurrentUserFn() }),
   component: Home,
 });
 
 const REPO_URL = "https://github.com/prescottprue/rigfile";
 
 function Home() {
+  const { user } = Route.useLoaderData();
+
   return (
     <main className="min-h-screen bg-surface px-4 py-12 sm:px-8">
       <div className="mx-auto max-w-3xl">
@@ -17,31 +21,36 @@ function Home() {
           <Logo className="mx-auto h-14 w-14 text-accent" />
           <h1 className="mt-3 text-4xl font-semibold text-ink">RigFile</h1>
           <p className="mt-1 text-lg font-medium text-ink-muted">
-            Every vehicle's file.
+            File information for any rig.
           </p>
           <p className="mx-auto mt-3 max-w-xl text-lg text-ink-muted">
             Service history, receipts, and documents for every rig you own — in
-            one place you control, accessible anywhere (even from Claude).
-            Self-hosted, open source, and yours to export.
+            one place you control, accessible anywhere (even from your AI
+            assistant). Self-hosted, open source, and yours to export.
           </p>
           <div className="mt-6 flex flex-wrap justify-center gap-3">
-            <Link
-              to="/join"
-              search={{ redirectTo: undefined }}
-              className={btnPrimary}
-            >
-              Sign up
-            </Link>
-            <Link
-              to="/login"
-              search={{ redirectTo: undefined }}
-              className={btnSecondary}
-            >
-              Log in
-            </Link>
-            <Link to="/vehicles" className={btnSecondary}>
-              Your vehicles
-            </Link>
+            {user ? (
+              <Link to="/vehicles" className={btnPrimary}>
+                Your vehicles
+              </Link>
+            ) : (
+              <>
+                <Link
+                  to="/join"
+                  search={{ redirectTo: undefined }}
+                  className={btnPrimary}
+                >
+                  Sign up
+                </Link>
+                <Link
+                  to="/login"
+                  search={{ redirectTo: undefined }}
+                  className={btnSecondary}
+                >
+                  Log in
+                </Link>
+              </>
+            )}
           </div>
         </header>
 
@@ -60,13 +69,13 @@ function Home() {
 
           <div className={`${card} p-6`}>
             <h2 className="text-lg font-semibold text-ink">
-              🤖 Talk to your garage from Claude
+              🤖 Talk to your garage from any AI
             </h2>
             <p className="mt-2 text-sm text-ink-muted">
-              RigFile is an MCP server: connect it to your own Claude account
-              and ask "what's due on the Jeep?" or "log the oil change I just
-              did" — from your phone, mid-wrench. You sign in with your RigFile
-              account; Claude only sees what you can see.
+              RigFile is an MCP server: connect it to your own AI assistant and
+              ask "what's due on the Jeep?" or "log the oil change I just did" —
+              from your phone, mid-wrench. You sign in with your RigFile
+              account; your AI only sees what you can see.
             </p>
           </div>
 
@@ -90,6 +99,43 @@ function Home() {
               source, so you can always run your own instance — on Cloudflare or
               a single self-hosted container — and take your data with you.
             </p>
+          </div>
+        </section>
+
+        <section className="mt-8">
+          <div className={`${card} p-6`}>
+            <h2 className="text-lg font-semibold text-ink">🚀 Get set up</h2>
+            <ol className="mt-2 list-decimal space-y-1 pl-5 text-sm text-ink-muted">
+              <li>
+                Create an account (or self-host your own instance) and add your
+                vehicles.
+              </li>
+              <li>
+                Log work, scan receipts, and set reminders due by date or
+                mileage.
+              </li>
+              <li>
+                Connect your AI assistant over MCP to query and log from chat —
+                the connector URL and steps live on your{" "}
+                <Link
+                  to="/profile"
+                  className="font-medium text-accent hover:underline"
+                >
+                  profile
+                </Link>{" "}
+                once you sign in.
+              </li>
+            </ol>
+            <div className="mt-4">
+              <a
+                href={REPO_URL}
+                target="_blank"
+                rel="noreferrer"
+                className={btnSecondary}
+              >
+                Setup &amp; self-hosting guide
+              </a>
+            </div>
           </div>
         </section>
 

--- a/app/styles.css
+++ b/app/styles.css
@@ -3,10 +3,10 @@
 /*
  * Semantic color tokens. Utilities like `bg-surface` / `text-ink` resolve
  * these CSS variables at runtime (via @theme inline), so toggling the
- * `.garage` class on <html> reskins the whole app without a rebuild.
+ * `.dark` class on <html> reskins the whole app without a rebuild.
  *
- * Garage Mode = high-contrast dark palette + larger base font, tuned for
- * reading at arm's length under bad shop lighting with greasy thumbs.
+ * Dark mode swaps the palette only — it never changes the base font size, so
+ * flipping the theme reskins in place without shifting the layout.
  */
 :root {
   --app-surface: #f4f5f7;
@@ -23,7 +23,7 @@
   --app-danger: #dc2626;
 }
 
-.garage {
+.dark {
   --app-surface: #0c0e11;
   --app-card: #171a20;
   --app-sunken: #101216;
@@ -55,9 +55,4 @@
 
 html {
   background-color: var(--app-surface);
-}
-
-/* Bigger type everywhere in the shop — Tailwind sizes are rem-based. */
-html.garage {
-  font-size: 18px;
 }


### PR DESCRIPTION
Visual + copy cleanup for the RigFile rebrand (follows the rename in #68).

## Brand mark
- New `app/components/Logo.tsx` — a clean **folder + car-silhouette** mark (single-color `currentColor` SVG, primitives so it stays crisp from favicon to hero). Used in the navbar badge and landing hero, replacing the **checkered-flag** 🏁 and wrench 🔧 emoji. Project target-date badge: 🏁 → 🎯.

## Dark mode — fixes the layout shift
- **Root cause:** `html.garage { font-size: 18px }` rebased every rem on toggle, growing the navbar and shifting the page down. Dark mode is now **color-only** — layout never moves.
- `.garage` class → `.dark`; "Garage Mode" toggle → a light/dark **`ThemeToggle`** (sun/moon). Persists `rigfile-theme`, falls back to the OS `prefers-color-scheme` on first load (no light flash).

## Home & account copy
- **Tagline → "File information for any rig."**
- **Provider-neutral MCP messaging** on both the landing page and the account page — "any AI" / "your AI assistant" (MCP isn't Claude-specific). Claude kept only as a concrete example in the connector steps. `ConnectClaude` → `ConnectAI`; fixed a raw `text-slate-900` to the `text-ink` token.
- **Auth-aware landing CTAs:** "Your vehicles" shows only when logged in; Sign up / Log in show only when logged out (a loader fetches the current user).
- **"Get set up" section** on the landing page → links to the GitHub setup & self-hosting guide and points to the in-app MCP connector URL on the profile page.
- README: tagline + RigFile framing; dark-mode feature note. CLAUDE.md: documents the `.dark` theme + Logo.

## Verified
- `npm run typecheck` ✅ · `npm run build` (Cloudflare) ✅ · Biome ✅ on changed files

> A stray gitignored worktree (`.claude/worktrees/drive`) breaks a full-tree `npm run lint` locally (its own nested `biome.json`); unrelated to this PR and invisible to CI. `git worktree remove .claude/worktrees/drive` to clear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)