### PR TITLE
fix(scan): make document flatten opt-in + memory/timeout safe (iOS)

### DIFF
--- a/app/components/DocumentScanner.tsx
+++ b/app/components/DocumentScanner.tsx
@@ -8,7 +8,7 @@ import {
   warpDocument,
 } from "~/lib/document-scan";
 
-type Status = "detecting" | "ready" | "flattening" | "unavailable";
+type Status = "idle" | "detecting" | "flattening" | "error";
 
 /** Clamp a fractional coordinate to the image. */
 function clamp01(n: number): number {
@@ -16,11 +16,12 @@ function clamp01(n: number): number {
 }
 
 /**
- * Full-screen document-scan modal: auto-detects the page's four corners,
- * lets the user nudge each one, then perspective-warps the photo flat (better
- * OCR, cleaner stored scan). OpenCV.js loads lazily on open; if it can't
- * load, the modal degrades to "crop instead" / "use original" so a scan is
- * never blocked. Browser-only — render from an event handler, never SSR.
+ * Full-screen document-scan modal. Opens instantly showing the photo with a
+ * draggable quad — no WASM yet. OpenCV.js (a ~10MB module) loads lazily only
+ * when the user taps "Auto-detect" or "Flatten", so a routine capture never
+ * pays that cost. Detection/warp run on capped-size images and are
+ * time-boxed, so they can't hang or OOM the tab on iOS. Browser-only — render
+ * from an event handler, never SSR.
  */
 export function DocumentScanner({
   file,
@@ -36,8 +37,9 @@ export function DocumentScanner({
 }) {
   const [url, setUrl] = useState<string | null>(null);
   const [box, setBox] = useState<{ w: number; h: number } | null>(null);
-  const [quad, setQuad] = useState<Quad | null>(null);
-  const [status, setStatus] = useState<Status>("detecting");
+  const [quad, setQuad] = useState<Quad>(defaultQuad());
+  const [status, setStatus] = useState<Status>("idle");
+  const [note, setNote] = useState<string | null>(null);
   const imgRef = useRef<HTMLImageElement>(null);
   const drag = useRef<{ corner: number; id: number } | null>(null);
 
@@ -47,31 +49,13 @@ export function DocumentScanner({
     return () => URL.revokeObjectURL(u);
   }, [file]);
 
-  // Kick off detection once on open. A failure to load OpenCV (network, old
-  // device) flips to the degraded state rather than throwing.
-  useEffect(() => {
-    let alive = true;
-    (async () => {
-      try {
-        const detected = await detectDocumentQuad(file);
-        if (!alive) return;
-        setQuad(detected ?? defaultQuad());
-        setStatus("ready");
-      } catch {
-        if (alive) setStatus("unavailable");
-      }
-    })();
-    return () => {
-      alive = false;
-    };
-  }, [file]);
-
   function onImgLoad() {
     const img = imgRef.current;
     if (img) setBox({ w: img.clientWidth, h: img.clientHeight });
   }
 
   function startDrag(e: React.PointerEvent, corner: number) {
+    if (status !== "idle") return;
     e.preventDefault();
     e.stopPropagation();
     e.currentTarget.setPointerCapture?.(e.pointerId);
@@ -81,7 +65,7 @@ export function DocumentScanner({
   function onPointerMove(e: React.PointerEvent) {
     const d = drag.current;
     const img = imgRef.current;
-    if (!d || !img || !quad) return;
+    if (!d || !img) return;
     const r = img.getBoundingClientRect();
     const x = clamp01((e.clientX - r.left) / r.width);
     const y = clamp01((e.clientY - r.top) / r.height);
@@ -92,20 +76,35 @@ export function DocumentScanner({
     drag.current = null;
   }
 
-  async function flatten() {
-    if (!quad) return;
-    setStatus("flattening");
+  async function autoDetect() {
+    setStatus("detecting");
+    setNote(null);
     try {
-      onConfirm(await warpDocument(file, quad));
+      const detected = await detectDocumentQuad(file);
+      setQuad(detected ?? defaultQuad());
+      if (!detected) {
+        setNote("No clear edges found — drag the corners to fit.");
+      }
+      setStatus("idle");
     } catch {
-      setStatus("unavailable");
+      setNote("Auto-detect isn't available here — drag the corners, or crop.");
+      setStatus("idle");
     }
   }
 
+  async function flatten() {
+    setStatus("flattening");
+    setNote(null);
+    try {
+      onConfirm(await warpDocument(file, quad));
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  const busy = status === "detecting" || status === "flattening";
   const points =
-    box && quad
-      ? quad.map((p) => `${p.x * box.w},${p.y * box.h}`).join(" ")
-      : "";
+    box && quad.map((p) => `${p.x * box.w},${p.y * box.h}`).join(" ");
 
   return (
     <div
@@ -130,7 +129,7 @@ export function DocumentScanner({
               onLoad={onImgLoad}
               className="max-h-[68vh] max-w-full select-none object-contain"
             />
-            {box && quad && status !== "unavailable" ? (
+            {box && status !== "error" ? (
               <>
                 <svg
                   className="pointer-events-none absolute inset-0 h-full w-full"
@@ -138,35 +137,36 @@ export function DocumentScanner({
                   preserveAspectRatio="none"
                   role="img"
                 >
-                  <title>Detected document outline</title>
+                  <title>Document outline</title>
                   <polygon
-                    points={points}
+                    points={points || ""}
                     fill="rgba(251,146,60,0.18)"
                     stroke="#fb923c"
                     strokeWidth={2}
                     vectorEffect="non-scaling-stroke"
                   />
                 </svg>
-                {quad.map((p, i) => (
-                  <span
-                    // biome-ignore lint/suspicious/noArrayIndexKey: fixed 4-corner quad, index is the identity
-                    key={i}
-                    aria-hidden
-                    onPointerDown={(e) => startDrag(e, i)}
-                    style={{
-                      left: p.x * box.w,
-                      top: p.y * box.h,
-                      touchAction: "none",
-                    }}
-                    className="absolute h-7 w-7 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-accent/70"
-                  />
-                ))}
+                {!busy &&
+                  quad.map((p, i) => (
+                    <span
+                      // biome-ignore lint/suspicious/noArrayIndexKey: fixed 4-corner quad, index is the identity
+                      key={i}
+                      aria-hidden
+                      onPointerDown={(e) => startDrag(e, i)}
+                      style={{
+                        left: p.x * box.w,
+                        top: p.y * box.h,
+                        touchAction: "none",
+                      }}
+                      className="absolute h-7 w-7 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-accent/70"
+                    />
+                  ))}
               </>
             ) : null}
           </div>
         ) : null}
 
-        {status === "detecting" || status === "flattening" ? (
+        {busy ? (
           <div className="absolute inset-0 flex items-center justify-center bg-black/50">
             <div className="flex items-center gap-3 rounded-xl bg-card px-4 py-3">
               <span
@@ -183,66 +183,86 @@ export function DocumentScanner({
         ) : null}
       </div>
 
-      {status === "unavailable" ? (
-        <div className="mx-auto mt-4 w-full max-w-md space-y-3">
-          <p className="rounded-xl border border-line bg-card p-3 text-center text-sm text-ink">
-            Couldn't run the document scanner on this device. Crop it manually
-            instead, or use the original photo.
+      <div className="mx-auto mt-4 w-full max-w-md space-y-2">
+        {note ? (
+          <p className="rounded-xl border border-line bg-card p-2 text-center text-xs text-ink-muted">
+            {note}
           </p>
-          <div className="flex gap-3">
-            <button
-              type="button"
-              className={`${btnSecondary} flex-1`}
-              onClick={() => onConfirm(file)}
-            >
-              Use original
-            </button>
-            <button
-              type="button"
-              className={`${btnPrimary} flex-1`}
-              onClick={() => onCropInstead(file)}
-            >
-              Crop instead
-            </button>
-          </div>
-          <button
-            type="button"
-            className="w-full text-center text-sm text-ink-muted hover:underline"
-            onClick={onCancel}
-          >
-            Cancel
-          </button>
-        </div>
-      ) : (
-        <div className="mx-auto mt-4 w-full max-w-md space-y-2">
-          <div className="flex gap-3">
-            <button
-              type="button"
-              className={`${btnSecondary} flex-1`}
-              onClick={onCancel}
-              disabled={status === "flattening"}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              className={`${btnPrimary} flex-1`}
-              onClick={flatten}
-              disabled={status !== "ready"}
-            >
-              {status === "flattening" ? "Flattening…" : "Flatten & use"}
-            </button>
-          </div>
-          <button
-            type="button"
-            className="w-full text-center text-sm text-ink-muted hover:underline"
-            onClick={() => onCropInstead(file)}
-            disabled={status === "flattening"}
-          >
-            Crop instead (no flatten)
-          </button>
-        </div>
-      )}
+        ) : null}
+
+        {status === "error" ? (
+          <>
+            <p className="rounded-xl border border-line bg-card p-3 text-center text-sm text-ink">
+              Couldn't flatten this photo on this device. Use the original, or
+              crop it manually.
+            </p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                className={`${btnSecondary} flex-1`}
+                onClick={() => onConfirm(file)}
+              >
+                Use original
+              </button>
+              <button
+                type="button"
+                className={`${btnPrimary} flex-1`}
+                onClick={() => onCropInstead(file)}
+              >
+                Crop instead
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                className={`${btnSecondary} flex-1`}
+                onClick={() => onConfirm(file)}
+                disabled={busy}
+              >
+                Use photo
+              </button>
+              <button
+                type="button"
+                className={`${btnPrimary} flex-1`}
+                onClick={flatten}
+                disabled={busy}
+              >
+                {status === "flattening" ? "Flattening…" : "Flatten & use"}
+              </button>
+            </div>
+            <div className="flex items-center justify-center gap-4 pt-1 text-sm text-ink-muted">
+              <button
+                type="button"
+                className="hover:underline disabled:opacity-50"
+                onClick={autoDetect}
+                disabled={busy}
+              >
+                ✨ Auto-detect
+              </button>
+              <span aria-hidden>·</span>
+              <button
+                type="button"
+                className="hover:underline disabled:opacity-50"
+                onClick={() => onCropInstead(file)}
+                disabled={busy}
+              >
+                Crop
+              </button>
+              <span aria-hidden>·</span>
+              <button
+                type="button"
+                className="hover:underline"
+                onClick={onCancel}
+              >
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/lib/document-scan.ts
+++ b/app/lib/document-scan.ts
@@ -18,8 +18,37 @@ export type Quad = [Point, Point, Point, Point];
 
 /** Largest edge dimension the detector runs at — keeps it fast on phones. */
 const DETECT_MAX = 1000;
+/**
+ * Largest edge dimension the warp runs at. Full phone photos (12MP+) decode
+ * into ~50MB RGBA Mats that crash iOS Safari; this caps peak memory. The
+ * scan flow downscales to 1600px afterward anyway, and a flattened document
+ * at 2000px is plenty legible / OCR-friendly.
+ */
+const WARP_MAX = 2000;
 /** A candidate quad must cover at least this fraction of the frame. */
 const MIN_AREA_FRACTION = 0.2;
+/** Guard against a decode that never settles (malformed/huge input). */
+const DECODE_TIMEOUT_MS = 15_000;
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out`)), ms);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
 
 export function distance(a: Point, b: Point): number {
   return Math.hypot(a.x - b.x, a.y - b.y);
@@ -74,21 +103,26 @@ export function defaultQuad(inset = 0.08): Quad {
 /** Decode a File to a canvas no larger than `maxDim`, orientation-corrected. */
 async function fileToCanvas(
   file: File,
-  maxDim?: number,
+  maxDim: number,
 ): Promise<HTMLCanvasElement | null> {
-  const bitmap = await createImageBitmap(file, {
-    imageOrientation: "from-image",
-  });
-  const scale = maxDim
-    ? Math.min(1, maxDim / Math.max(bitmap.width, bitmap.height))
-    : 1;
-  const canvas = document.createElement("canvas");
-  canvas.width = Math.max(1, Math.round(bitmap.width * scale));
-  canvas.height = Math.max(1, Math.round(bitmap.height * scale));
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return null;
-  ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
-  return canvas;
+  const bitmap = await withTimeout(
+    createImageBitmap(file, { imageOrientation: "from-image" }),
+    DECODE_TIMEOUT_MS,
+    "Image decode",
+  );
+  try {
+    const scale = Math.min(1, maxDim / Math.max(bitmap.width, bitmap.height));
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+    canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+    return canvas;
+  } finally {
+    // Release the full-resolution bitmap promptly — critical on iOS.
+    bitmap.close();
+  }
 }
 
 /**
@@ -163,8 +197,9 @@ export async function detectDocumentQuad(file: File): Promise<Quad | null> {
 
 /**
  * Perspective-warp the four fractional corners onto a flat rectangle and
- * return a JPEG. The warp runs on the full-resolution image; corner order is
- * normalized first so a user-dragged quad can't invert the output.
+ * return a JPEG. The source is capped at WARP_MAX first (memory safety on
+ * iOS); corner order is normalized so a user-dragged quad can't invert the
+ * output.
  */
 export async function warpDocument(
   file: File,
@@ -172,7 +207,7 @@ export async function warpDocument(
   { quality = 0.92 }: { quality?: number } = {},
 ): Promise<File> {
   const cv = await loadOpenCv();
-  const canvas = await fileToCanvas(file);
+  const canvas = await fileToCanvas(file, WARP_MAX);
   if (!canvas) return file;
 
   const quad = orderCorners(

--- a/app/lib/opencv.ts
+++ b/app/lib/opencv.ts
@@ -92,27 +92,52 @@ export interface Cv {
 
 const SCRIPT_ID = "opencv-js";
 const SCRIPT_SRC = "/opencv.js";
+/**
+ * Hard cap on WASM init. On memory-constrained devices (notably iOS Safari)
+ * the runtime can stall instantiating; without this the caller hangs forever.
+ * On timeout we reject AND clear the memo so a later attempt can retry.
+ */
+const LOAD_TIMEOUT_MS = 20_000;
 
 let cvPromise: Promise<Cv> | null = null;
-
-/** Resolve once the WASM runtime is live — immediately if it already is. */
-function whenReady(cv: Cv, resolve: (cv: Cv) => void): void {
-  if (typeof cv.Mat === "function") resolve(cv);
-  else cv.onRuntimeInitialized = () => resolve(cv);
-}
 
 export function loadOpenCv(): Promise<Cv> {
   cvPromise ??= new Promise<Cv>((resolve, reject) => {
     const win = window as unknown as { cv?: Cv };
+    let settled = false;
+
+    const succeed = (cv: Cv) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(cv);
+    };
+    const fail = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cvPromise = null; // allow a retry on the next attempt
+      reject(err);
+    };
+    const timer = setTimeout(
+      () => fail(new Error("OpenCV load timed out")),
+      LOAD_TIMEOUT_MS,
+    );
+
+    const whenReady = (cv: Cv) => {
+      if (typeof cv.Mat === "function") succeed(cv);
+      else cv.onRuntimeInitialized = () => succeed(cv);
+    };
+
     if (win.cv) {
-      whenReady(win.cv, resolve);
+      whenReady(win.cv);
       return;
     }
     const onLoad = () =>
       win.cv
-        ? whenReady(win.cv, resolve)
-        : reject(new Error("OpenCV loaded but window.cv is missing"));
-    const onError = () => reject(new Error("Failed to load OpenCV"));
+        ? whenReady(win.cv)
+        : fail(new Error("OpenCV loaded but window.cv is missing"));
+    const onError = () => fail(new Error("Failed to load OpenCV"));
 
     const existing = document.getElementById(
       SCRIPT_ID,


### PR DESCRIPTION
## The bug

On iOS Safari, the document scanner stalled on **"Finding the document…"** and then the **tab went black and couldn't recover** (had to open a new tab). That's the signature of a **WebContent process crash from memory pressure**, caused by the scanner (from #74) doing the worst possible thing on a memory-constrained device, automatically, on every scan:

- **Auto-loaded the 10 MB OpenCV WASM** the moment the scanner opened.
- **Decoded the full-resolution photo** (12 MP → ~50 MB RGBA Mats) for the warp.
- **No timeout**, so a stalled WASM init hung the UI forever — right up until the OOM killed the tab.

## The fix

**1. Flattening is now opt-in — no WASM on open.**
The scanner shows the photo with a draggable quad instantly. OpenCV loads only when the user taps **Auto-detect** or **Flatten & use**. A new **"Use photo"** action lets a routine capture proceed without ever loading WASM. **Cancel is always available** (no more trapped state).

**2. Everything async is time-boxed.**
`loadOpenCv` rejects after 20 s and clears its memo so a stall surfaces as a graceful fallback instead of an infinite "Finding the document…". The image decode is time-boxed too.

**3. Memory is capped.**
- Warp source capped at **2000 px** (was full-res — the ~50 MB Mats that OOM'd iOS). The scan flow downscales to 1600 px afterward anyway, so no quality loss.
- Detection stays at 1000 px.
- The decoded full-res bitmap is **`.close()`d immediately** after drawing to the working canvas — critical on iOS.

**4. Failures degrade, never dead-end.**
Any detect/warp/load failure drops to **Crop instead / Use original**.

## Why opt-in is the right default

The app is iOS-mobile-first ("garage phone capture"). Auto-loading a 10 MB WASM module on every receipt scan — including the many captures that don't need flattening — is the wrong default on a memory-constrained platform. Now the heavy path runs only on explicit intent, and even then it's capped and time-boxed.

## Testing
- `npm run validate` — typecheck + lint + **97 tests**.
- `npm run build` + `wrangler deploy --dry-run` — opencv still out of both bundles; Worker upload **0.70 MB gzip**.
- ⚠️ I can't reproduce iOS Safari here — this is a memory/lifecycle hardening fix reasoned from the crash signature. Worth a real-device pass: open scan → confirm it opens instantly without spinner, "Use photo" works with no WASM, and Auto-detect/Flatten work and recover gracefully.

Stacked conceptually on #74 (already merged); this branch is rebased onto `main` and contains only the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)