### PR TITLE
chore!: rename RigFile back to Logbook

### DIFF
--- a/.claude/commands/build-next.md
+++ b/.claude/commands/build-next.md
@@ -1,4 +1,4 @@
-You are a Wrench (builder agent) on the RigFile Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
+You are a Wrench (builder agent) on the Logbook Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
 
 Read `SERVICE_WRITER.md` for the full Wrench protocol (task selection algorithm, concurrency protocol, and rules). Read `CLAUDE.md`, `AGENTS.md`, and `AGENT.md` for code conventions and safety rules. Then follow this workflow:
 

--- a/.claude/commands/groom-issues.md
+++ b/.claude/commands/groom-issues.md
@@ -1,4 +1,4 @@
-You are the RigFile Service Writer. Your job is to groom GitHub Issues — triage new ones, build out specs, ask clarifying questions, reject out-of-scope requests, and revisit existing priorities.
+You are the Logbook Service Writer. Your job is to groom GitHub Issues — triage new ones, build out specs, ask clarifying questions, reject out-of-scope requests, and revisit existing priorities.
 
 Read `SERVICE_WRITER.md` for your full personality, decision framework, gatekeeping rules, security review guidelines, and grooming protocol. Then follow this workflow:
 
@@ -31,7 +31,7 @@ gh issue view <number>
 Then apply the grooming protocol from SERVICE_WRITER.md:
 
 ### a) Scope check
-- Does this issue relate to RigFile's purpose (tracking work/maintenance on vehicles, users, mechanics, parts, reporting)?
+- Does this issue relate to Logbook's purpose (tracking work/maintenance on vehicles, users, mechanics, parts, reporting)?
 - If **out of scope**: Leave a polite comment explaining why, add the `wontfix` label, and close the issue.
 
 ### b) Security check

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Local Postgres (via `npm run docker:dev`)
-DATABASE_URL="postgresql://postgres:postgres@localhost:5440/rigfile"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5440/logbook"
 
 # Must be at least 32 characters. Generate: openssl rand -base64 48
 SESSION_SECRET="change-me-to-something-random-at-least-32-chars-long"
@@ -9,7 +9,7 @@ UPLOADS_DIR="./data/uploads"
 
 # Google Drive sync (optional). When all three are set, the Profile page shows
 # a "Sync to Google Drive" panel that copies documents, scans, and a JSON
-# export into a "RigFile" folder in the user's Drive (drive.file scope — the
+# export into a "Logbook" folder in the user's Drive (drive.file scope — the
 # app only ever sees files it created). Create an OAuth 2.0 "Web application"
 # client in Google Cloud Console (Drive API enabled), and add the redirect URI
 # http://localhost:3000/auth/google/callback for local dev.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: "\U0001F4A1 Feature Request"
-description: Suggest a new feature or improvement for RigFile
+description: Suggest a new feature or improvement for Logbook
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/workflows/build-next.yml
+++ b/.github/workflows/build-next.yml
@@ -37,7 +37,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "github-actions[bot]"
           prompt: |
-            You are a Wrench (builder agent) on the RigFile Pit Lane crew. You've been asked to implement issue #${{ inputs.issue_number }}.
+            You are a Wrench (builder agent) on the Logbook Pit Lane crew. You've been asked to implement issue #${{ inputs.issue_number }}.
 
             Read `SERVICE_WRITER.md` for the full Wrench protocol. Read `CLAUDE.md`, `AGENTS.md`, and `AGENT.md` for code conventions and safety rules. Then follow this workflow:
 
@@ -136,7 +136,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "github-actions[bot]"
           prompt: |
-            You are a Wrench (builder agent) on the RigFile Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
+            You are a Wrench (builder agent) on the Logbook Pit Lane crew. Your job is to pick the next available feature from GitHub Issues and implement it end-to-end.
 
             Read `SERVICE_WRITER.md` for the full Wrench protocol. Read `CLAUDE.md`, `AGENTS.md`, and `AGENT.md` for code conventions and safety rules. Then follow this workflow:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,16 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: rigfile
+          POSTGRES_DB: logbook
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U postgres -d rigfile"
+          --health-cmd "pg_isready -U postgres -d logbook"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
     env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/rigfile
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/logbook
       SESSION_SECRET: ci-test-secret-must-be-at-least-32-characters-long
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/groom-issues.yml
+++ b/.github/workflows/groom-issues.yml
@@ -32,7 +32,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: "true"
           prompt: |
-            You are the RigFile Service Writer. Groom issue #${{ github.event.issue.number }}.
+            You are the Logbook Service Writer. Groom issue #${{ github.event.issue.number }}.
 
             Start by reading these files (use a single bash command: `cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`), then read the issue with `gh issue view ${{ github.event.issue.number }} -R ${{ github.repository }}`.
 
@@ -47,7 +47,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the RigFile Service Writer. Groom issue #${{ inputs.issue_number }}.
+            You are the Logbook Service Writer. Groom issue #${{ inputs.issue_number }}.
 
             Start by reading these files (use a single bash command: `cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`), then read the issue with `gh issue view ${{ inputs.issue_number }} -R ${{ github.repository }}`.
 
@@ -62,7 +62,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the RigFile Service Writer. Groom all ungroomed issues.
+            You are the Logbook Service Writer. Groom all ungroomed issues.
 
             Start by reading these files (use a single bash command: `cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`).
 
@@ -95,7 +95,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the RigFile Service Writer. A human has responded to clarification questions on issue #${{ github.event.issue.number }}.
+            You are the Logbook Service Writer. A human has responded to clarification questions on issue #${{ github.event.issue.number }}.
 
             Start by reading context files (`cat SERVICE_WRITER.md AGENTS.md CLAUDE.md`) and the full issue with comments (`gh issue view ${{ github.event.issue.number }} -R ${{ github.repository }} --comments`).
 
@@ -128,7 +128,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the RigFile Service Writer. A `/groom` command was issued on issue #${{ github.event.issue.number }}. This is a (re-)groom — start fresh.
+            You are the Logbook Service Writer. A `/groom` command was issued on issue #${{ github.event.issue.number }}. This is a (re-)groom — start fresh.
 
             First, strip stale status labels in one command:
             ```bash

--- a/.github/workflows/test-driver.yml
+++ b/.github/workflows/test-driver.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are the **Test Driver** on the RigFile Pit Crew. Read `TEST_DRIVER.md` for your full protocol. Also read `AGENTS.md` for project context.
+            You are the **Test Driver** on the Logbook Pit Crew. Read `TEST_DRIVER.md` for your full protocol. Also read `AGENTS.md` for project context.
 
             ## Your task
 

--- a/CHIEF_MECHANIC.md
+++ b/CHIEF_MECHANIC.md
@@ -7,7 +7,7 @@
 > gets rebuilt vs. replaced.
 
 Read `AGENT.md` for full project context. This file defines the Chief
-Mechanic's persona for evaluating and evolving the RigFile system.
+Mechanic's persona for evaluating and evolving the Logbook system.
 
 ## Identity
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — RigFile
+# CLAUDE.md — Logbook
 
 Quick reference for Claude Code sessions in this repo. Read `README.md` for
 user-facing context and tool-choice rationale.
@@ -93,7 +93,7 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
   `border-line`, `bg-accent`, `text-danger`/`warn`/`ok` (defined via
   `@theme inline` in `app/styles.css`). Dark mode toggles a `.dark` class on
   `<html>` (palette swap only — no font-size change, so the layout never
-  shifts; `ThemeToggle` in `_authed.tsx` persists `rigfile-theme`, and a
+  shifts; `ThemeToggle` in `_authed.tsx` persists `logbook-theme`, and a
   pre-paint script in `__root.tsx` applies it / falls back to the OS
   `prefers-color-scheme`) — raw slate/red classes won't reskin. The brand
   mark is `app/components/Logo.tsx` (folder + car silhouette, `currentColor`).
@@ -146,7 +146,7 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
    `odometer_readings`: standalone mileage entries (odometer, read_at, note,
    user_id) — "last odometer" is latest-by-date across logs + manual readings,
    ties broken by higher miles;
-   `google_connections`: per-user Google Drive OAuth-client tokens (RigFile is
+   `google_connections`: per-user Google Drive OAuth-client tokens (Logbook is
    the OAuth *client* here, the opposite role from the MCP server) — `drive.file`
    scope only, refresh token AES-GCM encrypted at rest, access token cached;
    `drive_synced_files`: idempotent map of synced source → Drive file/folder id
@@ -244,7 +244,7 @@ npm run test:e2e        # playwright smoke tests (needs dev server + DB)
     same `process.env` path as `SESSION_SECRET`, so no new wrangler binding.
 11. `server.ts` + `app/mcp/` — Worker entry (`main` in wrangler.jsonc):
     wraps the TanStack handler in `workers-oauth-provider`, mounts
-    `RigFileMCP.serve("/mcp")`, and re-exports the `RigFileMCP` Durable
+    `LogbookMCP.serve("/mcp")`, and re-exports the `LogbookMCP` Durable
     Object. `agent.server.ts` defines the MCP tools (`list_vehicles`,
     `get_vehicle_status`, `whats_due`, `log_work`, `complete_reminder`,
     `list_projects`, `add_project_item`, `update_item_status`) as thin
@@ -315,7 +315,7 @@ Remix/Prisma stack in places and are queued for a refresh pass.
   (#59 added `OAUTH_KV`) until the token gained `Workers KV Storage:Edit`.
   Fix lives in the Cloudflare dashboard token, not the repo.
 - **Cloudflare secrets are per-Worker-script; a rename drops them.** When
-  `name` in `wrangler.jsonc` changed (`vehicle-work-log` → `rigfile`), the
+  `name` in `wrangler.jsonc` changed (`vehicle-work-log` → `logbook`), the
   new script started with **no** secrets and the app threw at runtime
   (`SESSION_SECRET must be set and at least 32 characters long`). After any
   Worker rename, re-run `wrangler secret put` for every secret on the new
@@ -351,9 +351,9 @@ including a backlog of paper shop invoices.
   photo still attaches on save.
 - Deliberately NOT the Anthropic API — cost. Don't suggest it for this.
 
-### 2. RigFile MCP server (DONE — see "Files to know" #11)
+### 2. Logbook MCP server (DONE — see "Files to know" #11)
 
-So the crew can talk to RigFile from their own Claude accounts
+So the crew can talk to Logbook from their own Claude accounts
 (claude.ai custom connector, works on mobile). NOTE: rally-specific
 features stay OUT of the app — the app is generic vehicle maintenance;
 rally procedure lives in Scott's external rebelle-rally skill, which

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Self-host image: app + Postgres 16 + s6-overlay, one mounted /app/data volume.
 # Run with:
-#   docker run -d -p 3000:3000 -v rigfile-data:/app/data \
-#     -e SESSION_SECRET=... ghcr.io/scottprue/rigfile:latest
+#   docker run -d -p 3000:3000 -v logbook-data:/app/data \
+#     -e SESSION_SECRET=... ghcr.io/scottprue/logbook:latest
 
 ARG NODE_VERSION=24
 ARG S6_OVERLAY_VERSION=3.2.0.2
@@ -25,7 +25,7 @@ ARG S6_OVERLAY_VERSION
 ENV NODE_ENV=production
 ENV PGDATA=/app/data/postgresql
 ENV UPLOADS_DIR=/app/data/uploads
-ENV DATABASE_URL=postgresql://postgres:postgres@localhost:5432/rigfile
+ENV DATABASE_URL=postgresql://postgres:postgres@localhost:5432/logbook
 
 # Install Node and fetch tools
 RUN apk add --no-cache \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RigFile
+# Logbook
 
 **Every vehicle's file.**
 
@@ -159,9 +159,9 @@ single container. One command, one mounted volume:
 ```sh
 docker run -d \
   -p 3000:3000 \
-  -v rigfile-data:/app/data \
+  -v logbook-data:/app/data \
   -e SESSION_SECRET="$(openssl rand -base64 48)" \
-  ghcr.io/scottprue/rigfile:latest
+  ghcr.io/scottprue/logbook:latest
 ```
 
 Everything persistent (Postgres cluster + uploaded files) lives under
@@ -196,10 +196,10 @@ more than enough for this app).
 
 ```sh
 # Create R2 bucket
-npx wrangler r2 bucket create rigfile-uploads
+npx wrangler r2 bucket create logbook-uploads
 
 # Create Hyperdrive over Neon
-npx wrangler hyperdrive create rigfile-db --connection-string="$NEON_URL"
+npx wrangler hyperdrive create logbook-db --connection-string="$NEON_URL"
 # paste the returned id into wrangler.jsonc under hyperdrive[0].id
 
 # Create the KV namespace that stores MCP OAuth grants/tokens
@@ -368,13 +368,13 @@ breaking old bundles.
 ## Sync to Google Drive
 
 Optionally back your records up to your own Google Drive. From **Profile →
-Sync to Google Drive**, connect a Google account and hit **Sync now**: RigFile
-creates a single `RigFile` folder and copies your vehicle documents, receipt
+Sync to Google Drive**, connect a Google account and hit **Sync now**: Logbook
+creates a single `Logbook` folder and copies your vehicle documents, receipt
 scans, and a full JSON export (the same bundle as above) into it, organized
 per vehicle.
 
 It uses Google's [`drive.file`](https://developers.google.com/drive/api/guides/api-specific-auth)
-scope — the **least-privilege** Drive scope. RigFile can only see and modify
+scope — the **least-privilege** Drive scope. Logbook can only see and modify
 files **it created**; it can't list, read, or touch anything else in your
 Drive. The sync is one-way (app → Drive) and idempotent: re-running only
 uploads what's new and refreshes the JSON export. Disconnecting revokes the
@@ -402,7 +402,7 @@ tooling). See `.env.example`.
 
 ## Scan Bay — digitizing paper records
 
-A big part of RigFile is getting a backlog of paper shop invoices into the
+A big part of Logbook is getting a backlog of paper shop invoices into the
 app. Scan Bay does that locally, for **$0** — it runs a vision model on your own
 machine (Ollama + `qwen3-vl:8b` by default), so the receipts never leave your
 laptop and there's no per-page API cost.
@@ -470,10 +470,10 @@ Dev note: Workers AI has no local simulator, so the binding is dev-disabled
 unless you opt in with `CF_REMOTE_BINDINGS=1 npm run dev` (requires
 `wrangler login`); without it, dev scans use local Ollama.
 
-## RigFile MCP — talk to your garage from Claude
+## Logbook MCP — talk to your garage from Claude
 
 The Worker doubles as a remote MCP server at `/mcp`, so anyone on the crew
-can connect RigFile to their own Claude account (claude.ai → Settings →
+can connect Logbook to their own Claude account (claude.ai → Settings →
 Connectors → Add custom connector → `https://<your-worker-domain>/mcp`)
 and ask things like "what's due on the Jeep?" or "log the oil change I
 just did at 87,420 miles" — from a phone, mid-wrench.

--- a/SERVICE_WRITER.md
+++ b/SERVICE_WRITER.md
@@ -7,7 +7,7 @@
 
 ## Identity
 
-You are the **Service Writer** for RigFile — the PM agent on the
+You are the **Service Writer** for Logbook — the PM agent on the
 **Pit Lane** crew. You operate with memory across sessions, maintaining a
 living roadmap and making prioritization decisions grounded in user
 feedback, usage data, and the project's goal: a reliable, pleasant web app
@@ -75,7 +75,7 @@ When prioritizing, weight these factors:
 ### Gatekeeping & Scope Enforcement
 
 You are the **first line of defense** for the backlog. Not every request
-belongs in RigFile's roadmap. Your job is to say **no** when
+belongs in Logbook's roadmap. Your job is to say **no** when
 appropriate.
 
 **Accept** issues that:
@@ -130,7 +130,7 @@ follow this process for **each issue**:
 #### For new issues (no priority label yet):
 
 1. **Read** the full issue body and any existing comments
-2. **Validate scope** — Does this belong in RigFile? If not, reject
+2. **Validate scope** — Does this belong in Logbook? If not, reject
    per gatekeeping rules above
 3. **Security check** — Does anything look suspicious or unsafe? If so, flag
    per security rules above
@@ -191,7 +191,7 @@ follow this process for **each issue**:
 
 ## Context
 
-### What RigFile Does Today
+### What Logbook Does Today
 
 - **Users** — register (`/join`), login (`/login`), logout (`/logout`). Cookie
   sessions via `createCookieSessionStorage`.

--- a/app/components/Logo.tsx
+++ b/app/components/Logo.tsx
@@ -1,5 +1,5 @@
 /**
- * RigFile brand mark — a folder (filing/access) with a simple car silhouette
+ * Logbook brand mark — a folder (filing/access) with a simple car silhouette
  * (the rig). Single-color via `currentColor` so it inherits text color and
  * themes for light/dark; built from primitive shapes so it stays crisp at
  * favicon-to-hero sizes. Size it with a className (e.g. `h-6 w-6`).

--- a/app/components/ui.ts
+++ b/app/components/ui.ts
@@ -25,6 +25,9 @@ export const label = "block text-sm font-medium text-ink-muted";
 export const errorBox =
   "rounded-xl border border-danger/40 bg-danger/10 p-3 text-sm text-danger";
 
+export const okBox =
+  "rounded-xl border border-ok/40 bg-ok/10 p-3 text-sm text-ok";
+
 /** Selectable pill (service-type presets, status filters). */
 export function chip(selected: boolean) {
   return `inline-flex min-h-11 items-center rounded-full border px-4 text-sm font-semibold transition-colors ${

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -391,10 +391,10 @@ export const odometerReadings = pgTable(
   (t) => [index("odometer_readings_vehicle_idx").on(t.vehicleId)],
 );
 
-// Per-user Google Drive connection. Here RigFile is the OAuth *client* (the
-// user authorizes RigFile to write into their Drive) — the opposite role from
-// the MCP server, where RigFile is the OAuth provider. The `drive.file` scope
-// means RigFile can only see and touch files it created itself, never the
+// Per-user Google Drive connection. Here Logbook is the OAuth *client* (the
+// user authorizes Logbook to write into their Drive) — the opposite role from
+// the MCP server, where Logbook is the OAuth provider. The `drive.file` scope
+// means Logbook can only see and touch files it created itself, never the
 // rest of the user's Drive. `refreshTokenEnc` is AES-GCM encrypted at rest
 // (see app/google/crypto.server.ts); the access token is cached until expiry.
 export const googleConnections = pgTable("google_connections", {
@@ -410,7 +410,7 @@ export const googleConnections = pgTable("google_connections", {
     withTimezone: true,
     mode: "date",
   }),
-  // The id of the "RigFile" root folder created in the user's Drive.
+  // The id of the "Logbook" root folder created in the user's Drive.
   rootFolderId: text("root_folder_id"),
   scope: text(),
   lastSyncedAt: timestamp("last_synced_at", {
@@ -420,7 +420,7 @@ export const googleConnections = pgTable("google_connections", {
   ...timestamps,
 });
 
-// Maps a synced source object to the file/folder RigFile created in the user's
+// Maps a synced source object to the file/folder Logbook created in the user's
 // Drive, so re-syncing is idempotent and resumable: an already-synced
 // immutable blob (a vehicle document or log attachment) is skipped, folders
 // are reused, and the JSON export is updated in place. Rows cascade when the

--- a/app/google/drive.server.ts
+++ b/app/google/drive.server.ts
@@ -5,7 +5,7 @@
  * both Cloudflare Workers and Node.
  *
  * Everything here is scoped by the `drive.file` grant: these calls only ever
- * see or touch files RigFile itself created.
+ * see or touch files Logbook itself created.
  */
 
 const FILES_ENDPOINT = "https://www.googleapis.com/drive/v3/files";
@@ -58,7 +58,7 @@ export async function uploadFile({
   body: Uint8Array;
   parentId?: string;
 }): Promise<string> {
-  const boundary = `rigfile-${crypto.randomUUID()}`;
+  const boundary = `logbook-${crypto.randomUUID()}`;
   const metadata = JSON.stringify({
     name,
     ...(parentId ? { parents: [parentId] } : {}),

--- a/app/google/oauth.server.ts
+++ b/app/google/oauth.server.ts
@@ -1,5 +1,5 @@
 /**
- * Google OAuth 2.0 client — the side where RigFile authenticates *to* Google
+ * Google OAuth 2.0 client — the side where Logbook authenticates *to* Google
  * so it can write into the user's Drive. Plain `fetch` against Google's
  * endpoints (no `googleapis` SDK, which isn't Workers-friendly), so this runs
  * unchanged on Cloudflare Workers and Node.
@@ -8,7 +8,7 @@
  * same as SESSION_SECRET): GOOGLE_OAUTH_CLIENT_ID + GOOGLE_OAUTH_CLIENT_SECRET.
  * The redirect URI is derived per-request from the app origin and passed in.
  *
- * Scope is `drive.file` — RigFile can only access files it creates — plus
+ * Scope is `drive.file` — Logbook can only access files it creates — plus
  * `openid email` so we can show which Google account is connected.
  */
 

--- a/app/mcp/agent.server.ts
+++ b/app/mcp/agent.server.ts
@@ -23,7 +23,7 @@ import { getVehicle, getVehicleListItems } from "~/models/vehicle.server";
  * workers-oauth-provider on every authenticated /mcp request. Must stay a
  * type alias (not interface) to satisfy McpAgent's Record constraint.
  */
-export type RigFileMcpProps = {
+export type LogbookMcpProps = {
   userId: string;
   email: string;
 };
@@ -79,17 +79,17 @@ function reminderSummary(reminder: ReminderWithStatus) {
 }
 
 /**
- * Remote MCP server for RigFile. Every tool is a thin wrapper over the
+ * Remote MCP server for Logbook. Every tool is a thin wrapper over the
  * app/models layer, which enforces crew-membership authorization — tools
  * only supply the `userId` carried in the OAuth token props, so the MCP
  * surface can never read wider than the logged-in user could in the app.
  */
-export class RigFileMCP extends McpAgent<
+export class LogbookMCP extends McpAgent<
   Cloudflare.Env,
   unknown,
-  RigFileMcpProps
+  LogbookMcpProps
 > {
-  server = new McpServer({ name: "RigFile", version: "1.0.0" });
+  server = new McpServer({ name: "Logbook", version: "1.0.0" });
 
   private requireUserId(): string {
     const userId = this.props?.userId;

--- a/app/models/google-drive.server.ts
+++ b/app/models/google-drive.server.ts
@@ -50,8 +50,8 @@ export type DriveConnectionStatus = {
   lastSyncedAt: Date | null;
 };
 
-const ROOT_FOLDER_NAME = "RigFile";
-const EXPORT_FILE_NAME = "rigfile-export.json";
+const ROOT_FOLDER_NAME = "Logbook";
+const EXPORT_FILE_NAME = "logbook-export.json";
 /** Refresh the access token a minute before it actually expires. */
 const TOKEN_REFRESH_MARGIN_MS = 60_000;
 
@@ -97,7 +97,7 @@ export async function saveConnectionFromTokens({
     (existing ? await decryptSecret(existing.refreshTokenEnc) : null);
   if (!refreshToken) {
     throw new Error(
-      "Google did not return a refresh token. Remove RigFile from your Google account's third-party access and reconnect.",
+      "Google did not return a refresh token. Remove Logbook from your Google account's third-party access and reconnect.",
     );
   }
 
@@ -185,7 +185,7 @@ type SyncContext = {
 
 /**
  * Push the user's documents, scan/photo attachments, and a JSON data export
- * into a "RigFile" folder in their Google Drive. One-way (app → Drive) and
+ * into a "Logbook" folder in their Google Drive. One-way (app → Drive) and
  * idempotent: immutable blobs already mapped in `drive_synced_files` are
  * skipped, folders are reused, and the export is updated in place.
  *
@@ -349,7 +349,7 @@ async function syncBlob(
   }
 }
 
-/** Write (or refresh) the JSON data export at the RigFile root. */
+/** Write (or refresh) the JSON data export at the Logbook root. */
 async function syncExport(ctx: SyncContext, rootId: string): Promise<void> {
   const data = await buildUserExport(ctx.userId);
   if (!data) return;

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -11,7 +11,7 @@ import stylesHref from "../styles.css?url";
 
 // Applied before paint so dark mode doesn't flash light on reload. Falls back
 // to the OS color-scheme preference when the user hasn't picked a theme.
-const themeScript = `try{var t=localStorage.getItem("rigfile-theme");if(t==="dark"||(!t&&matchMedia("(prefers-color-scheme:dark)").matches))document.documentElement.classList.add("dark")}catch(e){}`;
+const themeScript = `try{var t=localStorage.getItem("logbook-theme");if(t==="dark"||(!t&&matchMedia("(prefers-color-scheme:dark)").matches))document.documentElement.classList.add("dark")}catch(e){}`;
 
 export const Route = createRootRoute({
   head: () => ({
@@ -21,12 +21,12 @@ export const Route = createRootRoute({
         name: "viewport",
         content: "width=device-width, initial-scale=1, viewport-fit=cover",
       },
-      { title: "RigFile" },
+      { title: "Logbook" },
       { name: "theme-color", content: "#0c0e11" },
       // iOS home-screen install: standalone chrome + dark status bar. iOS
       // reads these + the apple-touch-icon, not the web manifest.
       { name: "apple-mobile-web-app-capable", content: "yes" },
-      { name: "apple-mobile-web-app-title", content: "RigFile" },
+      { name: "apple-mobile-web-app-title", content: "Logbook" },
       {
         name: "apple-mobile-web-app-status-bar-style",
         content: "black-translucent",

--- a/app/routes/_authed.profile.tsx
+++ b/app/routes/_authed.profile.tsx
@@ -4,7 +4,15 @@ import { createServerFn } from "@tanstack/react-start";
 import { useEffect, useState } from "react";
 import { requireAuth } from "~/auth/session.server";
 import { ImageCropper } from "~/components/ImageCropper";
-import { btnSecondary, card } from "~/components/ui";
+import {
+  btnPrimary,
+  btnSecondary,
+  card,
+  errorBox,
+  input,
+  label,
+  okBox,
+} from "~/components/ui";
 import { downscaleImage } from "~/lib/image";
 import {
   type DriveConnectionStatus,
@@ -114,15 +122,15 @@ function ProfilePage() {
 
   return (
     <section className="space-y-10">
-      <h1 className="text-2xl font-semibold text-slate-900">Profile</h1>
+      <h1 className="text-2xl font-semibold text-ink">Profile</h1>
       <ProfileForm user={user} />
-      <hr className="border-slate-200" />
+      <hr className="border-line" />
       <PasswordForm />
-      <hr className="border-slate-200" />
+      <hr className="border-line" />
       <ConnectAI />
-      <hr className="border-slate-200" />
+      <hr className="border-line" />
       <GoogleDrive status={drive} />
-      <hr className="border-slate-200" />
+      <hr className="border-line" />
       <YourData />
     </section>
   );
@@ -192,9 +200,7 @@ function GoogleDrive({ status }: { status: DriveConnectionStatus }) {
 
   return (
     <div>
-      <h2 className="text-lg font-medium text-slate-900">
-        ☁️ Sync to Google Drive
-      </h2>
+      <h2 className="text-lg font-medium text-ink">☁️ Sync to Google Drive</h2>
       <div className={`${card} mt-4 max-w-lg p-5`}>
         <p className="text-sm text-ink-muted">
           Keep a copy of your records in your own Google Drive. Logbook creates
@@ -232,18 +238,14 @@ function GoogleDrive({ status }: { status: DriveConnectionStatus }) {
                 : "Not synced yet."}
             </p>
 
-            {error ? (
-              <p className="rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
-                {error}
-              </p>
-            ) : null}
+            {error ? <p className={errorBox}>{error}</p> : null}
             {result ? (
-              <p className="rounded border border-green-200 bg-green-50 p-2 text-sm text-green-700">
+              <p className={okBox}>
                 Synced: {result.created} added, {result.updated} updated,{" "}
                 {result.skipped} already current
                 {result.failed > 0 ? `, ${result.failed} failed` : ""}.
                 {result.errors.length > 0 ? (
-                  <span className="mt-1 block text-xs text-red-700">
+                  <span className="mt-1 block text-xs text-danger">
                     {result.errors.slice(0, 5).join("; ")}
                   </span>
                 ) : null}
@@ -255,7 +257,7 @@ function GoogleDrive({ status }: { status: DriveConnectionStatus }) {
                 type="button"
                 onClick={runSync}
                 disabled={pending !== null}
-                className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+                className={btnPrimary}
               >
                 {pending === "sync" ? "Syncing…" : "Sync now"}
               </button>
@@ -270,10 +272,7 @@ function GoogleDrive({ status }: { status: DriveConnectionStatus }) {
             </div>
           </div>
         ) : (
-          <a
-            href="/auth/google/start"
-            className="mt-4 inline-block rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
-          >
+          <a href="/auth/google/start" className={`${btnPrimary} mt-4`}>
             Connect Google Drive
           </a>
         )}
@@ -346,7 +345,7 @@ function ConnectAI() {
 function YourData() {
   return (
     <div>
-      <h2 className="text-lg font-medium text-slate-900">🔓 Your data</h2>
+      <h2 className="text-lg font-medium text-ink">🔓 Your data</h2>
       <div className={`${card} mt-4 max-w-lg p-5`}>
         <p className="text-sm text-ink-muted">
           Your records belong to you. Download your complete history — vehicles,
@@ -427,24 +426,13 @@ function ProfileForm({
 
   return (
     <div>
-      <h2 className="text-lg font-medium text-slate-900">Account details</h2>
+      <h2 className="text-lg font-medium text-ink">Account details</h2>
       <form onSubmit={onSubmit} className="mt-4 max-w-lg space-y-4">
-        {error ? (
-          <p className="rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
-            {error}
-          </p>
-        ) : null}
-        {success ? (
-          <p className="rounded border border-green-200 bg-green-50 p-2 text-sm text-green-700">
-            Profile updated.
-          </p>
-        ) : null}
+        {error ? <p className={errorBox}>{error}</p> : null}
+        {success ? <p className={okBox}>Profile updated.</p> : null}
 
         <div>
-          <label
-            htmlFor="profile-email"
-            className="block text-sm font-medium text-slate-700"
-          >
+          <label htmlFor="profile-email" className={label}>
             Email
           </label>
           <input
@@ -452,25 +440,25 @@ function ProfileForm({
             type="email"
             value={user.email}
             disabled
-            className="mt-1 w-full rounded border border-slate-200 bg-slate-50 p-2 text-slate-500"
+            className={`${input} bg-sunken text-ink-muted`}
           />
-          <p className="mt-1 text-xs text-slate-500">
+          <p className="mt-1 text-xs text-ink-muted">
             Email cannot be changed at this time.
           </p>
         </div>
 
-        <label className="block text-sm font-medium text-slate-700">
+        <label className={label}>
           Display name
           <input
             name="displayName"
             type="text"
             defaultValue={user.displayName ?? ""}
-            className="mt-1 w-full rounded border border-slate-300 p-2"
+            className={input}
           />
         </label>
 
         <div>
-          <label className="block text-sm font-medium text-slate-700">
+          <label className={label}>
             Profile image (cropped to a square)
             <input
               type="file"
@@ -506,11 +494,7 @@ function ProfileForm({
           />
         ) : null}
 
-        <button
-          type="submit"
-          disabled={pending}
-          className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
-        >
+        <button type="submit" disabled={pending} className={btnPrimary}>
           {pending ? "Saving…" : "Save changes"}
         </button>
       </form>
@@ -557,56 +541,46 @@ function PasswordForm() {
 
   return (
     <div>
-      <h2 className="text-lg font-medium text-slate-900">Change password</h2>
+      <h2 className="text-lg font-medium text-ink">Change password</h2>
       <form onSubmit={onSubmit} className="mt-4 max-w-lg space-y-4">
-        {error ? (
-          <p className="rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
-            {error}
-          </p>
-        ) : null}
+        {error ? <p className={errorBox}>{error}</p> : null}
         {success ? (
-          <p className="rounded border border-green-200 bg-green-50 p-2 text-sm text-green-700">
-            Password changed successfully.
-          </p>
+          <p className={okBox}>Password changed successfully.</p>
         ) : null}
 
-        <label className="block text-sm font-medium text-slate-700">
+        <label className={label}>
           Current password
           <input
             name="currentPassword"
             type="password"
             required
-            className="mt-1 w-full rounded border border-slate-300 p-2"
+            className={input}
           />
         </label>
 
-        <label className="block text-sm font-medium text-slate-700">
+        <label className={label}>
           New password
           <input
             name="newPassword"
             type="password"
             required
             minLength={8}
-            className="mt-1 w-full rounded border border-slate-300 p-2"
+            className={input}
           />
         </label>
 
-        <label className="block text-sm font-medium text-slate-700">
+        <label className={label}>
           Confirm new password
           <input
             name="confirmPassword"
             type="password"
             required
             minLength={8}
-            className="mt-1 w-full rounded border border-slate-300 p-2"
+            className={input}
           />
         </label>
 
-        <button
-          type="submit"
-          disabled={pending}
-          className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
-        >
+        <button type="submit" disabled={pending} className={btnPrimary}>
           {pending ? "Changing…" : "Change password"}
         </button>
       </form>

--- a/app/routes/_authed.profile.tsx
+++ b/app/routes/_authed.profile.tsx
@@ -197,10 +197,10 @@ function GoogleDrive({ status }: { status: DriveConnectionStatus }) {
       </h2>
       <div className={`${card} mt-4 max-w-lg p-5`}>
         <p className="text-sm text-ink-muted">
-          Keep a copy of your records in your own Google Drive. RigFile creates
-          a single <span className="font-medium text-ink">RigFile</span> folder
+          Keep a copy of your records in your own Google Drive. Logbook creates
+          a single <span className="font-medium text-ink">Logbook</span> folder
           and copies your vehicle documents, receipt scans, and a full data
-          export into it. Using Google's <code>drive.file</code> access, RigFile
+          export into it. Using Google's <code>drive.file</code> access, Logbook
           can only see files it created here — never the rest of your Drive.
         </p>
 
@@ -303,7 +303,7 @@ function ConnectAI() {
       <h2 className="text-lg font-medium text-ink">🤖 Connect your AI (MCP)</h2>
       <div className={`${card} mt-4 max-w-lg p-5`}>
         <p className="text-sm text-ink-muted">
-          RigFile is an MCP server, so you can talk to your garage from your own
+          Logbook is an MCP server, so you can talk to your garage from your own
           AI assistant — "what's due on the Jeep?", "log the oil change I just
           did at 87,420 miles" — from a phone, mid-wrench. Your AI signs in as{" "}
           <em>you</em>: it can only see and log to vehicles your account can
@@ -318,7 +318,7 @@ function ConnectAI() {
             )
           </li>
           <li>Paste the URL below</li>
-          <li>Sign in with your RigFile account and approve access</li>
+          <li>Sign in with your Logbook account and approve access</li>
         </ol>
         <div className="mt-4 flex gap-2">
           <input
@@ -351,9 +351,9 @@ function YourData() {
         <p className="text-sm text-ink-muted">
           Your records belong to you. Download your complete history — vehicles,
           logs, readings, vendors, tags, and parts — as JSON at any time.
-          RigFile is also{" "}
+          Logbook is also{" "}
           <a
-            href="https://github.com/prescottprue/rigfile"
+            href="https://github.com/prescottprue/logbook"
             target="_blank"
             rel="noreferrer"
             className="font-medium text-accent hover:underline"

--- a/app/routes/_authed.tsx
+++ b/app/routes/_authed.tsx
@@ -34,7 +34,7 @@ function ThemeToggle() {
     setDark(next);
     document.documentElement.classList.toggle("dark", next);
     try {
-      localStorage.setItem("rigfile-theme", next ? "dark" : "light");
+      localStorage.setItem("logbook-theme", next ? "dark" : "light");
     } catch {
       // private browsing — theme just won't persist
     }
@@ -96,7 +96,7 @@ function AuthedLayout() {
             >
               <Logo className="h-6 w-6" />
             </span>
-            <span>RigFile</span>
+            <span>Logbook</span>
           </Link>
           <div className="flex items-center gap-2">
             <ThemeToggle />

--- a/app/routes/account.export.tsx
+++ b/app/routes/account.export.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute("/account/export")({
 
         return Response.json(body, {
           headers: {
-            "content-disposition": `attachment; filename="rigfile-${body.user.email}.json"`,
+            "content-disposition": `attachment; filename="logbook-${body.user.email}.json"`,
           },
         });
       },

--- a/app/routes/authorize.tsx
+++ b/app/routes/authorize.tsx
@@ -32,7 +32,7 @@ function redirect(location: string): Response {
  * The MCP client (e.g. claude.ai) registered itself via dynamic client
  * registration, so the only trust signal we can show is what it claimed
  * about itself plus the redirect host. Scopes are not granular yet — a
- * grant means "act as you in RigFile".
+ * grant means "act as you in Logbook".
  */
 function consentPage({
   client,
@@ -51,7 +51,7 @@ function consentPage({
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Authorize ${clientName} — RigFile</title>
+<title>Authorize ${clientName} — Logbook</title>
 <style>
   body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
          background: #0f172a; color: #e2e8f0; font: 16px/1.5 system-ui, sans-serif; }
@@ -70,9 +70,9 @@ function consentPage({
 </head>
 <body>
 <main class="card">
-  <h1>🔧 Connect to RigFile</h1>
+  <h1>🔧 Connect to Logbook</h1>
   <p><span class="who">${clientName}</span> (redirects to <code>${redirectHost}</code>)
-     is asking to access RigFile as <span class="who">${escapeHtml(email)}</span>.</p>
+     is asking to access Logbook as <span class="who">${escapeHtml(email)}</span>.</p>
   <p>It will be able to:</p>
   <ul>
     <li>See your vehicles, logs, reminders, and projects</li>

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -17,7 +17,7 @@ export const Route = createFileRoute("/")({
   component: Home,
 });
 
-const REPO_URL = "https://github.com/prescottprue/rigfile";
+const REPO_URL = "https://github.com/prescottprue/logbook";
 
 function Home() {
   const { user } = Route.useLoaderData();
@@ -27,7 +27,7 @@ function Home() {
       <div className="mx-auto max-w-3xl">
         <header className="text-center">
           <Logo className="mx-auto h-14 w-14 text-accent" />
-          <h1 className="mt-3 text-4xl font-semibold text-ink">RigFile</h1>
+          <h1 className="mt-3 text-4xl font-semibold text-ink">Logbook</h1>
           <p className="mt-1 text-lg font-medium text-ink-muted">
             File information for any rig.
           </p>
@@ -68,7 +68,7 @@ function Home() {
               📷 Scan paper receipts — privately
             </h2>
             <p className="mt-2 text-sm text-ink-muted">
-              Snap a shop invoice and RigFile reads the date, mileage, cost, and
+              Snap a shop invoice and Logbook reads the date, mileage, cost, and
               work performed into a log entry, with the original photo attached.
               Extraction runs on self-hosted AI models — your records are never
               sent to third-party AI services.
@@ -80,9 +80,9 @@ function Home() {
               🤖 Talk to your garage from any AI
             </h2>
             <p className="mt-2 text-sm text-ink-muted">
-              RigFile is an MCP server: connect it to your own AI assistant and
+              Logbook is an MCP server: connect it to your own AI assistant and
               ask "what's due on the Jeep?" or "log the oil change I just did" —
-              from your phone, mid-wrench. You sign in with your RigFile
+              from your phone, mid-wrench. You sign in with your Logbook
               account; your AI only sees what you can see.
             </p>
           </div>
@@ -103,7 +103,7 @@ function Home() {
               🔓 Your data is yours
             </h2>
             <p className="mt-2 text-sm text-ink-muted">
-              Export your complete history as JSON at any time. RigFile is open
+              Export your complete history as JSON at any time. Logbook is open
               source, so you can always run your own instance — on Cloudflare or
               a single self-hosted container — and take your data with you.
             </p>

--- a/app/routes/join.tsx
+++ b/app/routes/join.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { signupFn } from "~/auth/server-fns";
+import { btnPrimary, card, errorBox, input, label } from "~/components/ui";
 
 export const Route = createFileRoute("/join")({
   component: JoinPage,
@@ -40,30 +41,21 @@ function JoinPage() {
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-slate-50 p-8">
-      <form
-        onSubmit={onSubmit}
-        className="w-full max-w-md rounded-2xl bg-white p-8 shadow-sm"
-      >
-        <h1 className="text-2xl font-semibold text-slate-900">
-          Create account
-        </h1>
-        {error ? (
-          <p className="mt-4 rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
-            {error}
-          </p>
-        ) : null}
-        <label className="mt-4 block text-sm font-medium text-slate-700">
+    <main className="flex min-h-screen items-center justify-center bg-surface p-8">
+      <form onSubmit={onSubmit} className={`${card} w-full max-w-md p-8`}>
+        <h1 className="text-2xl font-semibold text-ink">Create account</h1>
+        {error ? <p className={`mt-4 ${errorBox}`}>{error}</p> : null}
+        <label className={`mt-4 ${label}`}>
           Email
           <input
             name="email"
             type="email"
             required
             autoComplete="email"
-            className="mt-1 w-full rounded border border-slate-300 p-2"
+            className={input}
           />
         </label>
-        <label className="mt-4 block text-sm font-medium text-slate-700">
+        <label className={`mt-4 ${label}`}>
           Password
           <input
             name="password"
@@ -71,25 +63,25 @@ function JoinPage() {
             required
             minLength={8}
             autoComplete="new-password"
-            className="mt-1 w-full rounded border border-slate-300 p-2"
+            className={input}
           />
-          <span className="mt-1 block text-xs text-slate-500">
+          <span className="mt-1 block text-xs text-ink-muted">
             Minimum 8 characters.
           </span>
         </label>
         <button
           type="submit"
           disabled={pending}
-          className="mt-6 w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+          className={`${btnPrimary} mt-6 w-full`}
         >
           {pending ? "Creating…" : "Create account"}
         </button>
-        <p className="mt-4 text-center text-sm text-slate-600">
+        <p className="mt-4 text-center text-sm text-ink-muted">
           Already have an account?{" "}
           <Link
             to="/login"
             search={{ redirectTo: undefined }}
-            className="text-blue-600 hover:underline"
+            className="font-medium text-accent hover:underline"
           >
             Log in
           </Link>

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { loginFn } from "~/auth/server-fns";
+import { btnPrimary, card, errorBox, input, label } from "~/components/ui";
 
 export const Route = createFileRoute("/login")({
   component: LoginPage,
@@ -39,42 +40,35 @@ function LoginPage() {
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-slate-50 p-8">
-      <form
-        onSubmit={onSubmit}
-        className="w-full max-w-md rounded-2xl bg-white p-8 shadow-sm"
-      >
-        <h1 className="text-2xl font-semibold text-slate-900">Log in</h1>
-        {error ? (
-          <p className="mt-4 rounded border border-red-200 bg-red-50 p-2 text-sm text-red-700">
-            {error}
-          </p>
-        ) : null}
-        <label className="mt-4 block text-sm font-medium text-slate-700">
+    <main className="flex min-h-screen items-center justify-center bg-surface p-8">
+      <form onSubmit={onSubmit} className={`${card} w-full max-w-md p-8`}>
+        <h1 className="text-2xl font-semibold text-ink">Log in</h1>
+        {error ? <p className={`mt-4 ${errorBox}`}>{error}</p> : null}
+        <label className={`mt-4 ${label}`}>
           Email
           <input
             name="email"
             type="email"
             required
             autoComplete="email"
-            className="mt-1 w-full rounded border border-slate-300 p-2"
+            className={input}
           />
         </label>
-        <label className="mt-4 block text-sm font-medium text-slate-700">
+        <label className={`mt-4 ${label}`}>
           Password
-          <div className="relative mt-1">
+          <div className="relative">
             <input
               name="password"
               type={showPassword ? "text" : "password"}
               required
               minLength={8}
               autoComplete="current-password"
-              className="w-full rounded border border-slate-300 p-2 pr-16"
+              className={`${input} pr-16`}
             />
             <button
               type="button"
               onClick={() => setShowPassword((s) => !s)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-slate-500 hover:text-slate-700"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-ink-muted hover:text-ink"
             >
               {showPassword ? "Hide" : "Show"}
             </button>
@@ -83,16 +77,16 @@ function LoginPage() {
         <button
           type="submit"
           disabled={pending}
-          className="mt-6 w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+          className={`${btnPrimary} mt-6 w-full`}
         >
           {pending ? "Signing in…" : "Sign in"}
         </button>
-        <p className="mt-4 text-center text-sm text-slate-600">
+        <p className="mt-4 text-center text-sm text-ink-muted">
           No account?{" "}
           <Link
             to="/join"
             search={{ redirectTo: undefined }}
-            className="text-blue-600 hover:underline"
+            className="font-medium text-accent hover:underline"
           >
             Sign up
           </Link>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,13 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: rigfile
+      POSTGRES_DB: logbook
     ports:
       - "5440:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d rigfile"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d logbook"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker/s6-rc.d/init-app/run
+++ b/docker/s6-rc.d/init-app/run
@@ -7,12 +7,12 @@ until pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1; do
 done
 
 # Create the application database if it doesn't exist
-psql -h 127.0.0.1 -U postgres -tc "SELECT 1 FROM pg_database WHERE datname='rigfile'" \
+psql -h 127.0.0.1 -U postgres -tc "SELECT 1 FROM pg_database WHERE datname='logbook'" \
   | grep -q 1 \
-  || psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE rigfile"
+  || psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE logbook"
 
 # Run migrations (embedded SQL files in /app/migrations)
 cd /app
 for f in migrations/*.sql; do
-  [ -f "$f" ] && psql -h 127.0.0.1 -U postgres -d rigfile -v ON_ERROR_STOP=1 -f "$f"
+  [ -f "$f" ] && psql -h 127.0.0.1 -U postgres -d logbook -v ON_ERROR_STOP=1 -f "$f"
 done

--- a/e2e/mcp-oauth.spec.ts
+++ b/e2e/mcp-oauth.spec.ts
@@ -39,7 +39,7 @@ test.describe("MCP OAuth flow", () => {
     const callbackUrl = `${baseURL}${CALLBACK_PATH}`;
     const registerRes = await request.post("/oauth/register", {
       data: {
-        client_name: "RigFile E2E",
+        client_name: "Logbook E2E",
         redirect_uris: [callbackUrl],
         token_endpoint_auth_method: "none",
       },
@@ -66,7 +66,7 @@ test.describe("MCP OAuth flow", () => {
 
     // 3. Back on /authorize: consent screen, scoped to the logged-in user.
     await page.waitForURL("**/authorize**");
-    await expect(page.getByText("RigFile E2E")).toBeVisible();
+    await expect(page.getByText("Logbook E2E")).toBeVisible();
     await expect(page.getByText(testEmail)).toBeVisible();
     await page.getByRole("button", { name: /approve/i }).click();
 
@@ -105,15 +105,15 @@ test.describe("MCP OAuth flow", () => {
         params: {
           protocolVersion: "2025-03-26",
           capabilities: {},
-          clientInfo: { name: "rigfile-e2e", version: "1.0.0" },
+          clientInfo: { name: "logbook-e2e", version: "1.0.0" },
         },
       },
     });
     expect(initRes.status()).toBe(200);
     const initBody = await initRes.text();
-    expect(initBody).toContain("RigFile");
+    expect(initBody).toContain("Logbook");
 
-    // 7. tools/list on the same MCP session shows the RigFile tool set.
+    // 7. tools/list on the same MCP session shows the Logbook tool set.
     const sessionId = initRes.headers()["mcp-session-id"];
     expect(sessionId).toBeTruthy();
     const toolsRes = await request.post("/mcp", {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "rigfile",
+  "name": "logbook",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rigfile",
+      "name": "logbook",
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.8.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rigfile",
+  "name": "logbook",
   "private": true,
   "type": "module",
   "engines": {
@@ -28,7 +28,7 @@
     "scan:extract": "node --import tsx scripts/scan-bay/scan.ts",
     "scan:import": "node --env-file=.env --import tsx scripts/scan-bay/import.ts",
     "docker:dev": "docker compose up -d",
-    "docker:build": "docker build -t rigfile:local .",
+    "docker:build": "docker build -t logbook:local .",
     "validate": "npm run typecheck && npm run lint && npm run test -- --run"
   },
   "dependencies": {

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "RigFile",
-  "short_name": "RigFile",
+  "name": "Logbook",
+  "short_name": "Logbook",
   "description": "Vehicle maintenance logbook — work logs, reminders, receipt scans, and documents for your rigs.",
   "id": "/",
   "start_url": "/",

--- a/server.ts
+++ b/server.ts
@@ -1,7 +1,7 @@
 import OAuthProvider from "@cloudflare/workers-oauth-provider";
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
 
-import { RigFileMCP } from "./app/mcp/agent.server";
+import { LogbookMCP } from "./app/mcp/agent.server";
 import { runWithOAuthHelpers } from "./app/mcp/oauth-context.server";
 
 const app = createServerEntry({
@@ -12,7 +12,7 @@ const app = createServerEntry({
 
 // Durable Object class backing /mcp sessions — wrangler.jsonc binds it as
 // MCP_OBJECT. Must be re-exported from the worker entry.
-export { RigFileMCP };
+export { LogbookMCP };
 
 // The OAuthProvider wraps the whole Worker: it serves the OAuth protocol
 // endpoints itself (/oauth/token, /oauth/register, /.well-known/*), gates
@@ -21,7 +21,7 @@ export { RigFileMCP };
 // renders the login/consent UI inside the TanStack app — to the site.
 export default new OAuthProvider({
   apiRoute: "/mcp",
-  apiHandler: RigFileMCP.serve("/mcp"),
+  apiHandler: LogbookMCP.serve("/mcp"),
   defaultHandler: {
     fetch: (request: Request, env: Cloudflare.Env) =>
       Promise.resolve(

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,16 +1,16 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "rigfile",
+  "name": "logbook",
   "compatibility_date": "2026-01-15",
   "compatibility_flags": ["nodejs_compat"],
   // Custom entry: wraps the TanStack Start handler in workers-oauth-provider
-  // and exports the RigFileMCP Durable Object (see server.ts).
+  // and exports the LogbookMCP Durable Object (see server.ts).
   "main": "./server.ts",
   "observability": {
     "enabled": true
   },
   // Hyperdrive pools TCP Postgres connections from Workers. Create with:
-  //   wrangler hyperdrive create rigfile-db --connection-string="$NEON_URL"
+  //   wrangler hyperdrive create logbook-db --connection-string="$NEON_URL"
   // Then paste the returned id below.
   "hyperdrive": [
     {
@@ -19,15 +19,15 @@
       "id": "d0a95e6693424f2e9f3e9bb7f1af4b19",
       // In dev, wrangler/miniflare routes Hyperdrive requests to this URL so
       // the local Postgres from `npm run docker:dev` stands in for Neon.
-      "localConnectionString": "postgresql://postgres:postgres@localhost:5440/rigfile"
+      "localConnectionString": "postgresql://postgres:postgres@localhost:5440/logbook"
     }
   ],
   // R2 bucket holds avatar uploads. Create with:
-  //   wrangler r2 bucket create rigfile-uploads
+  //   wrangler r2 bucket create logbook-uploads
   "r2_buckets": [
     {
       // REPLACE WITH YOUR R2_BUCKET NAME FROM CLOUDFLARE
-      "bucket_name": "rigfile-prod-uploads",
+      "bucket_name": "logbook-prod-uploads",
       "binding": "UPLOADS"
     }
   ],
@@ -48,7 +48,7 @@
   "kv_namespaces": [
     {
       "binding": "OAUTH_KV",
-      "id": "15912863509549d2b3c133efe58db783"
+      "id": "7813b95e047d40fca5839eefec8cccc4"
     }
   ],
   // Durable Object backing MCP sessions at /mcp (agents SDK McpAgent).
@@ -56,14 +56,14 @@
     "bindings": [
       {
         "name": "MCP_OBJECT",
-        "class_name": "RigFileMCP"
+        "class_name": "LogbookMCP"
       }
     ]
   },
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["RigFileMCP"]
+      "new_sqlite_classes": ["LogbookMCP"]
     }
   ]
   // SESSION_SECRET is a Wrangler secret. Set with:


### PR DESCRIPTION
Reverts the RigFile rebrand back to **Logbook** after negative feedback on the RigFile name, and fixes dark mode on the auth + account pages. The brand mark (folder + car silhouette `Logo.tsx`) is unchanged.

## 1. Rename RigFile → Logbook (`chore!`)
Across code, config, docs, CI, and agent workflows.

**Naming convention** (clean single token, mirroring how `rigfile` was used):
- **`Logbook`** — display/brand name + the `LogbookMCP` Durable Object class
- **`logbook`** — everything else (no hyphen): worker name, R2 bucket (`logbook-prod-uploads`), Hyperdrive, Postgres DB, npm package, docker image (`ghcr.io/scottprue/logbook`)

**Infra recreated** ("start clean", no data migration):
- ✅ New R2 bucket `logbook-prod-uploads`
- ✅ New KV namespace (bound as `OAUTH_KV`, id pasted into `wrangler.jsonc`)
- ✅ Worker `name` → `logbook`, DO class → `LogbookMCP` (fresh `v1` sqlite migration)
- ♻️ Hyperdrive id reused (same prod Neon DB)
- ✅ GitHub repo renamed `prescottprue/rigfile` → `prescottprue/logbook`

## 2. Dark-mode fix (`fix(ui)`)
The login (`/login`), signup (`/join`), and account (`/profile`) pages used raw Tailwind palette classes (`bg-white`, `text-slate-900`, `bg-blue-600`, red/green alert boxes) that don't respond to the `.dark` class — headers and form fields were stuck light/dark. Swapped for the app's semantic tokens + shared `ui.ts` recipes (`card`, `input`, `label`, `btnPrimary`, `errorBox`, new `okBox`) so they reskin with the theme.

## Verification
- `npm run typecheck` ✓ · CF `npm run build` ✓ · **97/97 vitest** ✓ (fresh local `logbook` DB) · biome clean (3 pre-existing optional-chain warnings only)
- Zero `rigfile`/`RigFile` references remain

## ⚠️ Deploy follow-ups (manual)
- The renamed `logbook` Worker is a **fresh script** — re-set per-script secrets: `SESSION_SECRET`, `GOOGLE_OAUTH_CLIENT_ID`/`_SECRET`, `GOOGLE_TOKEN_KEY`. (No new binding *types*, so the deploy token perms are fine.)
- Worker hostname moves to `logbook.*.workers.dev` → update the Google OAuth **redirect URI**.
- Old `rigfile` Worker / `rigfile-prod-uploads` bucket / old KV namespace are now orphaned and can be deleted after the new deploy is confirmed.
- Gitignored `.env` `DATABASE_URL` still needs its one-line change to `…/logbook` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)